### PR TITLE
feat: burns historical data, closes #14

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,11 @@
 
 > Global rules (workflow, git, TypeScript, Biome) are in `/c/web/CLAUDE.md`. This file covers only what's specific to this project.
 
+## Git Workflow
+- **Never commit or write code directly on `master`.** Always create a feature branch first (`feat/`, `fix/`, `chore/`, `docs/`) and check it out before making any changes.
+- Branch from `master` for all new work.
+- Merge back to `master` via PR.
+
 ## Project Overview
 Tauri 2 + React 19 + TypeScript **Android-only** app for personal climbing route logging and beta tracking.
 Local-first SQLite. Supabase for cloud sync and auth (email/password; magic link planned). Admin-managed reference data (grades, location hierarchy, routes).
@@ -31,6 +36,7 @@ src/
                            # ProfileView, SettingsView
                            # admin/LocationManagerView, GradesManagerView, RouteVerificationView
   features/climbs/         # climbs.store, climbs.queries, climbs.service, climbs.schema
+  features/burns/          # burns.queries, burns.service, burns.schema
   features/routes/         # routes.queries, routes.service, routes.schema
   features/locations/      # locations.queries, locations.service, downloads.service
   features/grades/         # grades.queries, grades.service, grades.schema, grades-seed.ts
@@ -47,6 +53,7 @@ src/
 | Domain | Owner | Sync direction |
 |---|---|---|
 | `climbs` | Current user | Bidirectional, full push/pull (Realtime planned) |
+| `burns` | Current user | Bidirectional, full push/pull |
 | `users` | Current user | Bidirectional |
 | `grades_cache` | Admin | One-way pull; seeded from `grades-seed.ts` |
 | `countries_cache`, `regions_cache` | Admin | One-way pull; always synced on launch |

--- a/src/features/burns/README.md
+++ b/src/features/burns/README.md
@@ -1,0 +1,55 @@
+# src/features/burns
+
+Per-user timestamped notes on a climb representing a single attempt or session. Burns live inline on `ClimbDetailView` — no dedicated route.
+
+---
+
+## Schema (`burns.schema.ts`)
+
+| Schema | Purpose |
+|---|---|
+| `BurnSchema` | Full DB record: `id, climb_id, user_id, date, outcome, notes, created_at, updated_at, deleted_at` |
+| `BurnFormSchema` | Form input: `date, notes` |
+
+Types: `Burn`, `BurnFormValues`
+
+The `outcome` column exists in the DB but defaults to `'attempt'` and is not exposed in the UI.
+
+---
+
+## Service (`burns.service.ts`)
+
+| Function | Description |
+|---|---|
+| `fetchBurns(climbId)` | All non-deleted burns for a climb, sorted date DESC |
+| `insertBurn(climbId, userId, data)` | Insert with `crypto.randomUUID()`, outcome defaults to `'attempt'` |
+| `updateBurn(id, data)` | Update date and notes |
+| `softDeleteBurn(id)` | Set `deleted_at` |
+| `applyRemoteBurn(burn)` | `INSERT OR REPLACE` preserving server timestamps |
+
+---
+
+## Queries (`burns.queries.ts`)
+
+| Hook | Description |
+|---|---|
+| `useBurns(climbId)` | Query with key `["burns", climbId]` |
+| `useAddBurn()` | Mutation → `insertBurn` + invalidate + silent push |
+| `useUpdateBurn()` | Mutation → `updateBurn` + invalidate + silent push |
+| `useDeleteBurn()` | Mutation → `softDeleteBurn` + invalidate + silent push |
+
+All mutations trigger a silent `pushBurns(userId)` after success.
+
+---
+
+## Sync
+
+`pushBurns` and `pullBurns` in `sync.service.ts` mirror the climbs pattern. Burns are included in `useSync` launch sync and Realtime subscription.
+
+---
+
+## Data domain
+
+| Domain | Owner | Sync direction |
+|---|---|---|
+| `burns` | Current user | Bidirectional, full push/pull |

--- a/src/features/burns/burns.queries.ts
+++ b/src/features/burns/burns.queries.ts
@@ -1,0 +1,74 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useAuthStore } from "@/features/auth/auth.store";
+import { pushBurns } from "@/features/sync/sync.service";
+import { useUiStore } from "@/stores/ui.store";
+import type { BurnFormValues } from "./burns.schema";
+import {
+	fetchBurns,
+	insertBurn,
+	softDeleteBurn,
+	updateBurn,
+} from "./burns.service";
+
+const BURNS_KEY = "burns";
+
+const silentPush = (userId: string | undefined) => {
+	if (!userId) return;
+	const { addToast } = useUiStore.getState();
+	pushBurns(userId)
+		.then(() => addToast({ message: "Synced", type: "success" }))
+		.catch(() =>
+			addToast({ message: "Sync failed — saved offline", type: "error" }),
+		);
+};
+
+export function useBurns(climbId: string) {
+	return useQuery({
+		queryKey: [BURNS_KEY, climbId],
+		queryFn: () => fetchBurns(climbId),
+		enabled: !!climbId,
+	});
+}
+
+export function useAddBurn() {
+	const qc = useQueryClient();
+	const userId = useAuthStore((s) => s.user?.id);
+	return useMutation({
+		mutationFn: ({
+			climbId,
+			data,
+		}: {
+			climbId: string;
+			data: BurnFormValues;
+		}) => insertBurn(climbId, userId ?? "", data),
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: [BURNS_KEY] });
+			silentPush(userId);
+		},
+	});
+}
+
+export function useUpdateBurn() {
+	const qc = useQueryClient();
+	const userId = useAuthStore((s) => s.user?.id);
+	return useMutation({
+		mutationFn: ({ id, data }: { id: string; data: BurnFormValues }) =>
+			updateBurn(id, data),
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: [BURNS_KEY] });
+			silentPush(userId);
+		},
+	});
+}
+
+export function useDeleteBurn() {
+	const qc = useQueryClient();
+	const userId = useAuthStore((s) => s.user?.id);
+	return useMutation({
+		mutationFn: (id: string) => softDeleteBurn(id),
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: [BURNS_KEY] });
+			silentPush(userId);
+		},
+	});
+}

--- a/src/features/burns/burns.schema.ts
+++ b/src/features/burns/burns.schema.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+export const BurnSchema = z.object({
+	id: z.string(),
+	climb_id: z.string(),
+	user_id: z.string(),
+	date: z.string(),
+	outcome: z.string(),
+	notes: z.string().nullable().optional(),
+	created_at: z.string(),
+	updated_at: z.string(),
+	deleted_at: z.string().nullable().optional(),
+});
+
+export type Burn = z.infer<typeof BurnSchema>;
+
+export const BurnFormSchema = z.object({
+	date: z.string().min(1, "Date is required"),
+	notes: z.string().optional(),
+});
+
+export type BurnFormValues = z.infer<typeof BurnFormSchema>;

--- a/src/features/burns/burns.service.ts
+++ b/src/features/burns/burns.service.ts
@@ -1,0 +1,65 @@
+import { getDb } from "@/lib/db";
+import type { Burn, BurnFormValues } from "./burns.schema";
+
+export async function fetchBurns(climbId: string): Promise<Burn[]> {
+	const db = await getDb();
+	return db.select<Burn[]>(
+		"SELECT * FROM burns WHERE climb_id = ? AND deleted_at IS NULL ORDER BY date ASC",
+		[climbId],
+	);
+}
+
+export async function insertBurn(
+	climbId: string,
+	userId: string,
+	data: BurnFormValues,
+): Promise<void> {
+	const db = await getDb();
+	const id = crypto.randomUUID();
+	await db.execute(
+		`INSERT INTO burns (id, climb_id, user_id, date, outcome, notes)
+     VALUES (?, ?, ?, ?, 'attempt', ?)`,
+		[id, climbId, userId, data.date, data.notes ?? null],
+	);
+}
+
+export async function updateBurn(
+	id: string,
+	data: BurnFormValues,
+): Promise<void> {
+	const db = await getDb();
+	await db.execute(
+		`UPDATE burns SET date = ?, notes = ?
+     WHERE id = ? AND deleted_at IS NULL`,
+		[data.date, data.notes ?? null, id],
+	);
+}
+
+export async function softDeleteBurn(id: string): Promise<void> {
+	const db = await getDb();
+	await db.execute(
+		"UPDATE burns SET deleted_at = datetime('now') WHERE id = ?",
+		[id],
+	);
+}
+
+export async function applyRemoteBurn(burn: Burn): Promise<void> {
+	const db = await getDb();
+	await db.execute(
+		`INSERT OR REPLACE INTO burns
+     (id, climb_id, user_id, date, outcome, notes,
+      created_at, updated_at, deleted_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		[
+			burn.id,
+			burn.climb_id,
+			burn.user_id,
+			burn.date,
+			burn.outcome,
+			burn.notes ?? null,
+			burn.created_at,
+			burn.updated_at,
+			burn.deleted_at ?? null,
+		],
+	);
+}

--- a/src/features/sync/sync.service.ts
+++ b/src/features/sync/sync.service.ts
@@ -1,3 +1,4 @@
+import type { Burn } from "@/features/burns/burns.schema";
 import type { Climb } from "@/features/climbs/climbs.schema";
 import { getDb } from "@/lib/db";
 import { supabase } from "@/lib/supabase";
@@ -84,6 +85,56 @@ export async function pullClimbs(
 				row.route_location ?? null,
 				row.link ?? null,
 				row.route_id ?? null,
+				row.created_at,
+				row.updated_at,
+				row.deleted_at ?? null,
+			],
+		);
+	}
+}
+
+// ── Burns push ───────────────────────────────────────────────────────────────
+
+export async function pushBurns(userId: string, since?: string): Promise<void> {
+	const db = await getDb();
+	const burns = await db.select<Burn[]>(
+		since
+			? "SELECT * FROM burns WHERE user_id = ? AND updated_at > ?"
+			: "SELECT * FROM burns WHERE user_id = ?",
+		since ? [userId, since] : [userId],
+	);
+	if (burns.length === 0) return;
+
+	const { error } = await supabase.from("burns").upsert(burns, {
+		onConflict: "id",
+	});
+	if (error) throw error;
+}
+
+// ── Burns pull ───────────────────────────────────────────────────────────────
+
+export async function pullBurns(userId: string, since?: string): Promise<void> {
+	let query = supabase.from("burns").select("*").eq("user_id", userId);
+	if (since) query = query.gt("updated_at", since);
+
+	const { data, error } = await query;
+	if (error) throw error;
+	if (!data || data.length === 0) return;
+
+	const db = await getDb();
+	for (const row of data) {
+		await db.execute(
+			`INSERT OR REPLACE INTO burns
+       (id, climb_id, user_id, date, outcome, notes,
+        created_at, updated_at, deleted_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			[
+				row.id,
+				row.climb_id,
+				row.user_id,
+				row.date,
+				row.outcome,
+				row.notes ?? null,
 				row.created_at,
 				row.updated_at,
 				row.deleted_at ?? null,

--- a/src/hooks/useSync.ts
+++ b/src/hooks/useSync.ts
@@ -1,5 +1,7 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect } from "react";
+import type { Burn } from "@/features/burns/burns.schema";
+import { applyRemoteBurn } from "@/features/burns/burns.service";
 import type { Climb } from "@/features/climbs/climbs.schema";
 import { applyRemoteClimb } from "@/features/climbs/climbs.service";
 import { pullGrades } from "@/features/grades/grades.service";
@@ -9,7 +11,9 @@ import {
 } from "@/features/locations/locations.service";
 import {
 	getSyncMeta,
+	pullBurns,
 	pullClimbs,
+	pushBurns,
 	pushClimbs,
 	setSyncMeta,
 } from "@/features/sync/sync.service";
@@ -34,6 +38,8 @@ export function useSync(userId: string | undefined) {
 
 				await pushClimbs(userId, since);
 				await pullClimbs(userId, since);
+				await pushBurns(userId, since);
+				await pullBurns(userId, since);
 				await pullGrades();
 				await pullCountries();
 				await pullRegions();
@@ -42,6 +48,7 @@ export function useSync(userId: string | undefined) {
 				await setSyncMeta(now);
 
 				queryClient.invalidateQueries({ queryKey: ["climbs"] });
+				queryClient.invalidateQueries({ queryKey: ["burns"] });
 				queryClient.invalidateQueries({ queryKey: ["grades"] });
 				queryClient.invalidateQueries({ queryKey: ["countries"] });
 				queryClient.invalidateQueries({ queryKey: ["regions"] });
@@ -57,7 +64,7 @@ export function useSync(userId: string | undefined) {
 		// Realtime subscription — applies live server changes between manual syncs.
 		// Handles INSERT and UPDATE events (soft deletes arrive as UPDATE with deleted_at set).
 		const channel = supabase
-			.channel("climbs-realtime")
+			.channel("user-realtime")
 			.on(
 				"postgres_changes",
 				{
@@ -71,6 +78,21 @@ export function useSync(userId: string | undefined) {
 						await applyRemoteClimb(payload.new as Climb);
 					}
 					queryClient.invalidateQueries({ queryKey: ["climbs"] });
+				},
+			)
+			.on(
+				"postgres_changes",
+				{
+					event: "*",
+					schema: "public",
+					table: "burns",
+					filter: `user_id=eq.${userId}`,
+				},
+				async (payload) => {
+					if (payload.new && Object.keys(payload.new).length > 0) {
+						await applyRemoteBurn(payload.new as Burn);
+					}
+					queryClient.invalidateQueries({ queryKey: ["burns"] });
 				},
 			)
 			.subscribe();

--- a/src/views/ClimbDetailView.tsx
+++ b/src/views/ClimbDetailView.tsx
@@ -1,8 +1,15 @@
 import { useNavigate, useParams } from "@tanstack/react-router";
-import { ChevronDown, ExternalLink } from "lucide-react";
+import { ChevronDown, ExternalLink, Pencil, Plus, Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Button } from "@/components/atoms/Button";
+import { Input } from "@/components/atoms/Input";
 import { Spinner } from "@/components/atoms/Spinner";
+import {
+	useAddBurn,
+	useBurns,
+	useDeleteBurn,
+	useUpdateBurn,
+} from "@/features/burns/burns.queries";
 import { useClimb } from "@/features/climbs/climbs.queries";
 import { useClimbsStore } from "@/features/climbs/climbs.store";
 import { useRoute } from "@/features/routes/routes.queries";
@@ -14,8 +21,21 @@ const ClimbDetailView = () => {
 	const navigate = useNavigate();
 	const { data: climb, isLoading } = useClimb(climbId);
 	const { data: linkedRoute } = useRoute(climb?.route_id);
+	const { data: burns } = useBurns(climbId);
+	const addBurn = useAddBurn();
+	const updateBurn = useUpdateBurn();
+	const deleteBurn = useDeleteBurn();
 	const setSelectedClimbId = useClimbsStore((s) => s.setSelectedClimbId);
 	const [movesOpen, setMovesOpen] = useState(false);
+	const [burnsOpen, setBurnsOpen] = useState(false);
+	const [showAddBurn, setShowAddBurn] = useState(false);
+	const [addDate, setAddDate] = useState(() =>
+		new Date().toISOString().slice(0, 10),
+	);
+	const [addNotes, setAddNotes] = useState("");
+	const [editingBurnId, setEditingBurnId] = useState<string | null>(null);
+	const [editDate, setEditDate] = useState("");
+	const [editNotes, setEditNotes] = useState("");
 
 	useEffect(() => {
 		setSelectedClimbId(climbId);
@@ -125,6 +145,185 @@ const ClimbDetailView = () => {
 			>
 				Edit
 			</Button>
+
+			{/* Burns section */}
+			<div className="rounded-md bg-surface-card">
+				<button
+					type="button"
+					className="flex items-center justify-between w-full p-3 text-sm text-text-secondary"
+					onClick={() => setBurnsOpen(!burnsOpen)}
+				>
+					<span>Burns ({burns?.length ?? 0})</span>
+					<ChevronDown
+						size={16}
+						className={cn(
+							"transition-transform",
+							burnsOpen && "rotate-180",
+						)}
+					/>
+				</button>
+				{burnsOpen && (
+					<div className="flex flex-col gap-2 px-3 pb-3">
+						<button
+							type="button"
+							className="flex items-center gap-1 text-sm text-accent-primary self-start"
+							onClick={() => {
+								setShowAddBurn(!showAddBurn);
+								setAddDate(new Date().toISOString().slice(0, 10));
+								setAddNotes("");
+							}}
+						>
+							<Plus size={16} />
+							Add burn
+						</button>
+
+						{showAddBurn && (
+							<div className="rounded-[--radius-md] bg-surface-input p-3 flex flex-col gap-2">
+								<Input
+									type="date"
+									value={addDate}
+									onChange={(e) => setAddDate(e.target.value)}
+								/>
+								<Input
+									placeholder="Notes (optional)"
+									value={addNotes}
+									onChange={(e) => setAddNotes(e.target.value)}
+								/>
+								<Button
+									size="small"
+									disabled={!addDate || addBurn.isPending}
+									onClick={() => {
+										addBurn.mutate(
+											{
+												climbId,
+												data: {
+													date: addDate,
+													notes: addNotes || undefined,
+												},
+											},
+											{
+												onSuccess: () => {
+													setShowAddBurn(false);
+													setAddDate(
+														new Date().toISOString().slice(0, 10),
+													);
+													setAddNotes("");
+												},
+											},
+										);
+									}}
+								>
+									Save
+								</Button>
+							</div>
+						)}
+
+						{burns && burns.length > 0 ? (
+							<ul className="flex flex-col gap-2">
+								{burns.map((burn) => (
+									<li
+										key={burn.id}
+										className="border-l border-text-primary pl-2"
+									>
+										{editingBurnId === burn.id ? (
+											<div className="flex flex-col gap-2">
+												<Input
+													type="date"
+													value={editDate}
+													onChange={(e) =>
+														setEditDate(e.target.value)
+													}
+												/>
+												<Input
+													placeholder="Notes (optional)"
+													value={editNotes}
+													onChange={(e) =>
+														setEditNotes(e.target.value)
+													}
+												/>
+												<div className="flex gap-2">
+													<Button
+														size="small"
+														disabled={
+															!editDate || updateBurn.isPending
+														}
+														onClick={() => {
+															updateBurn.mutate(
+																{
+																	id: burn.id,
+																	data: {
+																		date: editDate,
+																		notes:
+																			editNotes || undefined,
+																	},
+																},
+																{
+																	onSuccess: () =>
+																		setEditingBurnId(null),
+																},
+															);
+														}}
+													>
+														Save
+													</Button>
+													<Button
+														size="small"
+														variant="outlined"
+														onClick={() =>
+															setEditingBurnId(null)
+														}
+													>
+														Cancel
+													</Button>
+												</div>
+											</div>
+										) : (
+											<div className="flex items-center justify-between">
+												<div>
+													<p className="text-sm font-semibold">
+														{burn.date}
+													</p>
+													{burn.notes && (
+														<p className="text-sm text-text-secondary">
+															{burn.notes}
+														</p>
+													)}
+												</div>
+												<div className="flex items-center gap-3">
+													<button
+														type="button"
+														className="text-text-secondary"
+														onClick={() => {
+															setEditingBurnId(burn.id);
+															setEditDate(burn.date);
+															setEditNotes(burn.notes ?? "");
+														}}
+													>
+														<Pencil size={16} />
+													</button>
+													<button
+														type="button"
+														className="text-text-secondary"
+														onClick={() =>
+															deleteBurn.mutate(burn.id)
+														}
+													>
+														<Trash2 size={16} />
+													</button>
+												</div>
+											</div>
+										)}
+									</li>
+								))}
+							</ul>
+						) : (
+							<p className="text-sm text-text-secondary">
+								No burns logged yet.
+							</p>
+						)}
+					</div>
+				)}
+			</div>
 
 			{moves.length > 0 && (
 				<div className="rounded-md bg-surface-card">

--- a/src/views/README.md
+++ b/src/views/README.md
@@ -47,7 +47,7 @@ Loads `useClimbs()`. Renders search input, `FilterPanel` molecule, and filtered 
 Renders `ClimbForm` organism in "add" mode. Reads optional search params (`routeId`, `routeName`, `grade`, `routeType`) to pre-fill the form when logging a specific route from `CragView`. On success navigates to `/`.
 
 ### ClimbDetailView `/climbs/$climbId`
-Loads `useClimb(climbId)`. Displays all climb fields. Has "Edit" button → `/climbs/$climbId/edit`.
+Loads `useClimb(climbId)` and `useBurns(climbId)`. Displays all climb fields. Has "Edit" button → `/climbs/$climbId/edit`. Burns section with inline add/edit forms and soft-delete. Each burn has a date and optional notes.
 
 ### EditClimbView `/climbs/$climbId/edit`
 Loads `useClimb(climbId)`. Renders `ClimbForm` in "edit" mode with prefilled values. If `climb.route_id` is null, shows a "Link to route" search section (`useLinkClimbToRoute`). On success navigates back to detail.


### PR DESCRIPTION
## Summary
- Burns feature module (schema, service, queries) following the climbs pattern
- Sync integration: `pushBurns`/`pullBurns` + Realtime subscription
- Collapsible burns list on ClimbDetailView with inline add/edit/delete
- CLAUDE.md updated: burns in folder structure, data domains, git workflow rules

## Test plan
- [ ] Add a burn on ClimbDetailView — appears in list sorted oldest to newest
- [ ] Edit a burn inline — date and notes update correctly
- [ ] Delete a burn — immediately disappears (soft delete)
- [ ] Burns sync to Supabase (silent push after each mutation)
- [ ] Burns pull from Supabase on app launch sync
- [ ] Date displays correctly without timezone offset

🤖 Generated with [Claude Code](https://claude.com/claude-code)