### PR TITLE
chore: add GitHub Actions workflow for on-demand APK builds

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -1,0 +1,102 @@
+name: Build APK
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_type:
+        description: "Build type (debug or release)"
+        required: true
+        default: debug
+        type: choice
+        options:
+          - debug
+          - release
+
+jobs:
+  build:
+    name: Build ${{ inputs.build_type }} APK
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # ── Java ──────────────────────────────────────────────────────────────
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: temurin
+
+      # ── Android SDK + NDK ─────────────────────────────────────────────────
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android NDK r27c
+        run: |
+          sdkmanager "ndk;27.2.12479018"
+          echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/27.2.12479018" >> $GITHUB_ENV
+
+      # ── Rust ──────────────────────────────────────────────────────────────
+      - name: Set up Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android,armv7-linux-androideabi
+
+      - name: Cache Rust build artefacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target"
+
+      # ── Node / pnpm ───────────────────────────────────────────────────────
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: pnpm
+
+      - name: Install frontend dependencies
+        run: pnpm install
+
+      # ── Signing ───────────────────────────────────────────────────────────
+      # Secrets required in repo Settings → Secrets and variables → Actions:
+      #   KEYSTORE_BASE64      — base64-encoded .jks file
+      #                          Generate: base64 -w 0 betaapp-release.jks
+      #   KEY_ALIAS            — key alias inside the keystore
+      #   KEYSTORE_PASSWORD    — store + key password
+      - name: Write keystore + properties
+        env:
+          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+        run: |
+          KEYSTORE_PATH="$GITHUB_WORKSPACE/betaapp-release.jks"
+          echo "$KEYSTORE_BASE64" | base64 --decode > "$KEYSTORE_PATH"
+          cat > src-tauri/gen/android/keystore.properties <<EOF
+          storeFile=$KEYSTORE_PATH
+          keyAlias=$KEY_ALIAS
+          password=$KEYSTORE_PASSWORD
+          EOF
+
+      # ── Build ─────────────────────────────────────────────────────────────
+      - name: Build ${{ inputs.build_type }} APK
+        run: |
+          if [ "${{ inputs.build_type }}" = "release" ]; then
+            pnpm tauri android build --release --target aarch64
+          else
+            pnpm tauri android build --debug --target aarch64
+          fi
+
+      # ── Upload ────────────────────────────────────────────────────────────
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: betaapp-${{ inputs.build_type }}-${{ github.run_number }}
+          path: src-tauri/gen/android/app/build/outputs/apk/${{ inputs.build_type }}/app-${{ inputs.build_type }}.apk
+          if-no-files-found: error
+          retention-days: 30


### PR DESCRIPTION
Adds .github/workflows/build-apk.yml with a workflow_dispatch trigger
so debug or release APKs can be built from the GitHub UI, CLI, or API.

Sets up JDK 17, Android SDK + NDK r27c, Rust (stable + aarch64 targets),
pnpm/Node 20, writes the keystore from repository secrets, runs
`pnpm tauri android build`, and uploads the APK as a workflow artifact.

Required secrets: KEYSTORE_BASE64, KEY_ALIAS, KEYSTORE_PASSWORD

https://claude.ai/code/session_01HTmtBkjtJMctAXooo5heC9