### PR TITLE
fix: resolve sync errors — offline detection, migration race, idempot…

### DIFF
--- a/src/components/molecules/SyncStatus.tsx
+++ b/src/components/molecules/SyncStatus.tsx
@@ -1,18 +1,43 @@
-import { CheckCircle, Loader2, WifiOff } from "lucide-react";
+import { AlertCircle, CheckCircle, Loader2, RefreshCw, WifiOff } from "lucide-react";
 import { useSyncStore } from "@/features/sync/sync.store";
 
 export const SyncStatus = () => {
 	const status = useSyncStore((s) => s.status);
 	const lastSyncedAt = useSyncStore((s) => s.lastSyncedAt);
+	const triggerSync = useSyncStore((s) => s.triggerSync);
 
 	// Don't show anything until a sync has been attempted
 	if (status === "idle" && !lastSyncedAt) return null;
 
+	const retryButton = (
+		<button
+			type="button"
+			onClick={() => triggerSync?.()}
+			className="ml-1 text-text-secondary active:opacity-60"
+			aria-label="Retry sync"
+		>
+			<RefreshCw size={12} />
+		</button>
+	);
+
 	if (status === "syncing") {
 		return <Loader2 size={12} className="animate-spin text-text-secondary" />;
 	}
+	if (status === "offline") {
+		return (
+			<span className="flex items-center">
+				<WifiOff size={12} className="text-text-muted" />
+				{retryButton}
+			</span>
+		);
+	}
 	if (status === "error") {
-		return <WifiOff size={12} className="text-red-400" />;
+		return (
+			<span className="flex items-center">
+				<AlertCircle size={12} className="text-red-400" />
+				{retryButton}
+			</span>
+		);
 	}
 	return <CheckCircle size={12} className="text-accent-primary" />;
 };

--- a/src/features/locations/locations.service.ts
+++ b/src/features/locations/locations.service.ts
@@ -143,14 +143,14 @@ export async function checkRegionStaleness(): Promise<string[]> {
 	const ids = downloaded.map((r) => r.region_id);
 	const { data, error } = await supabase
 		.from("regions")
-		.select("id, updated_at")
+		.select("id, created_at")
 		.in("id", ids);
 	if (error) throw error;
 
 	const serverMap = new Map<string, string>(
-		(data as unknown as { id: string; updated_at: string }[]).map((r) => [
+		(data as unknown as { id: string; created_at: string }[]).map((r) => [
 			r.id,
-			r.updated_at,
+			r.created_at,
 		]),
 	);
 
@@ -239,12 +239,12 @@ export async function downloadRegion(regionId: string): Promise<void> {
 	// 0. Fetch region metadata (including server updated_at for staleness tracking)
 	const { data: regionMeta, error: regionMetaError } = await supabase
 		.from("regions")
-		.select("updated_at")
+		.select("created_at")
 		.eq("id", regionId)
 		.single();
 	if (regionMetaError) throw regionMetaError;
 	const serverUpdatedAt: string | null =
-		(regionMeta as unknown as { updated_at?: string } | null)?.updated_at ??
+		(regionMeta as unknown as { created_at?: string } | null)?.created_at ??
 		null;
 
 	// 1. Pull sub_regions

--- a/src/features/sync/sync.store.ts
+++ b/src/features/sync/sync.store.ts
@@ -1,22 +1,28 @@
 import { create } from "zustand";
 
-type SyncStatus = "idle" | "syncing" | "error";
+type SyncStatus = "idle" | "syncing" | "error" | "offline";
 
 interface SyncStore {
 	status: SyncStatus;
 	lastSyncedAt: string | null;
 	error: string | null;
+	triggerSync: (() => void) | null;
 	setSyncing: () => void;
 	setSuccess: () => void;
 	setError: (error: string) => void;
+	setOffline: () => void;
+	setTriggerSync: (fn: () => void) => void;
 }
 
 export const useSyncStore = create<SyncStore>((set) => ({
 	status: "idle",
 	lastSyncedAt: null,
 	error: null,
+	triggerSync: null,
 	setSyncing: () => set({ status: "syncing", error: null }),
 	setSuccess: () =>
 		set({ status: "idle", lastSyncedAt: new Date().toISOString() }),
 	setError: (error) => set({ status: "error", error }),
+	setOffline: () => set({ status: "offline", error: null }),
+	setTriggerSync: (fn) => set({ triggerSync: fn }),
 }));

--- a/src/hooks/useSync.ts
+++ b/src/hooks/useSync.ts
@@ -1,5 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { useEffect } from "react";
+import { useCallback, useEffect } from "react";
 import type { Burn } from "@/features/burns/burns.schema";
 import { applyRemoteBurn } from "@/features/burns/burns.service";
 import type { Climb } from "@/features/climbs/climbs.schema";
@@ -31,58 +31,78 @@ import { supabase } from "@/lib/supabase";
 
 export function useSync(userId: string | undefined) {
 	const queryClient = useQueryClient();
-	const { setSyncing, setSuccess, setError } = useSyncStore();
+	const { setSyncing, setSuccess, setError, setOffline, setTriggerSync } =
+		useSyncStore();
+
+	// Delta push/pull if we have a stored timestamp; full sync on first run.
+	// Reference data (grades, countries, regions) always does a full pull —
+	// it's small and admin-owned so no delta is needed.
+	const runSync = useCallback(async () => {
+		if (!userId) return;
+
+		if (!navigator.onLine) {
+			setOffline();
+			return;
+		}
+
+		setSyncing();
+		try {
+			const { last_synced_at } = await getSyncMeta();
+			const since = last_synced_at ?? undefined;
+
+			await pushClimbs(userId, since);
+			await pullClimbs(userId, since);
+			await pushBurns(userId, since);
+			await pullBurns(userId, since);
+			await pushClimbImages(userId, since);
+			await pullClimbImages(userId, since);
+			await pushClimbImagePins(userId, since);
+			await pullClimbImagePins(userId, since);
+			await pullGrades();
+			await pullCountries();
+			await pullRegions();
+			await checkRegionStaleness().then(() => {
+				queryClient.invalidateQueries({ queryKey: ["stale_region_ids"] });
+			});
+			await pullRouteImages(since);
+			await pullWallImages(since);
+			await pushRouteLinks(userId, since);
+			await pullRouteLinks(since);
+
+			const now = new Date().toISOString();
+			await setSyncMeta(now);
+
+			queryClient.invalidateQueries({ queryKey: ["climbs"] });
+			queryClient.invalidateQueries({ queryKey: ["burns"] });
+			queryClient.invalidateQueries({ queryKey: ["climb-images"] });
+			queryClient.invalidateQueries({ queryKey: ["climb-image-pins"] });
+			queryClient.invalidateQueries({ queryKey: ["grades"] });
+			queryClient.invalidateQueries({ queryKey: ["countries"] });
+			queryClient.invalidateQueries({ queryKey: ["regions"] });
+			queryClient.invalidateQueries({ queryKey: ["route-images"] });
+			queryClient.invalidateQueries({ queryKey: ["wall-images"] });
+			queryClient.invalidateQueries({ queryKey: ["route_links"] });
+			setSuccess();
+		} catch (err) {
+			console.error("Sync error:", JSON.stringify(err));
+			setError(err instanceof Error ? err.message : JSON.stringify(err));
+		}
+	}, [
+		userId,
+		setSyncing,
+		setSuccess,
+		setError,
+		setOffline,
+		queryClient,
+	]);
+
+	// Register triggerSync in the store so SyncStatus can call it without prop drilling.
+	useEffect(() => {
+		setTriggerSync(runSync);
+	}, [runSync, setTriggerSync]);
 
 	useEffect(() => {
 		if (!userId) return;
-
-		// Delta push/pull if we have a stored timestamp; full sync on first run.
-		// Reference data (grades, countries, regions) always does a full pull —
-		// it's small and admin-owned so no delta is needed.
-		const runSync = async () => {
-			setSyncing();
-			try {
-				const { last_synced_at } = await getSyncMeta();
-				const since = last_synced_at ?? undefined;
-
-				await pushClimbs(userId, since);
-				await pullClimbs(userId, since);
-				await pushBurns(userId, since);
-				await pullBurns(userId, since);
-				await pushClimbImages(userId, since);
-				await pullClimbImages(userId, since);
-				await pushClimbImagePins(userId, since);
-				await pullClimbImagePins(userId, since);
-				await pullGrades();
-				await pullCountries();
-				await pullRegions();
-				await checkRegionStaleness().then(() => {
-					queryClient.invalidateQueries({ queryKey: ["stale_region_ids"] });
-				});
-				await pullRouteImages(since);
-				await pullWallImages(since);
-				await pushRouteLinks(userId, since);
-				await pullRouteLinks(since);
-
-				const now = new Date().toISOString();
-				await setSyncMeta(now);
-
-				queryClient.invalidateQueries({ queryKey: ["climbs"] });
-				queryClient.invalidateQueries({ queryKey: ["burns"] });
-				queryClient.invalidateQueries({ queryKey: ["climb-images"] });
-				queryClient.invalidateQueries({ queryKey: ["climb-image-pins"] });
-				queryClient.invalidateQueries({ queryKey: ["grades"] });
-				queryClient.invalidateQueries({ queryKey: ["countries"] });
-				queryClient.invalidateQueries({ queryKey: ["regions"] });
-				queryClient.invalidateQueries({ queryKey: ["route-images"] });
-				queryClient.invalidateQueries({ queryKey: ["wall-images"] });
-				queryClient.invalidateQueries({ queryKey: ["route_links"] });
-				setSuccess();
-			} catch (err) {
-				console.error("Sync error:", err);
-				setError(err instanceof Error ? err.message : "Sync failed");
-			}
-		};
 
 		runSync();
 
@@ -125,5 +145,5 @@ export function useSync(userId: string | undefined) {
 		return () => {
 			supabase.removeChannel(channel);
 		};
-	}, [userId, setSyncing, setSuccess, setError, queryClient]);
+	}, [userId, runSync, queryClient]);
 }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -5,19 +5,27 @@ export interface DbAdapter {
 	select<T>(sql: string, params?: unknown[]): Promise<T>;
 }
 
-let _db: DbAdapter | null = null;
+let _dbReady: Promise<DbAdapter> | null = null;
+
+// Injected by tests via setDb — bypasses the lazy-init path.
+let _testDb: DbAdapter | null = null;
 
 export function setDb(adapter: DbAdapter): void {
-	_db = adapter;
+	_testDb = adapter;
+	_dbReady = Promise.resolve(adapter);
 }
 
-export async function getDb(): Promise<DbAdapter> {
-	if (!_db) {
-		const db = await Database.load("sqlite:betaapp.db");
-		_db = db as unknown as DbAdapter;
-		await runMigrations(_db);
+export function getDb(): Promise<DbAdapter> {
+	if (_testDb) return Promise.resolve(_testDb);
+	if (!_dbReady) {
+		_dbReady = (async () => {
+			const db = await Database.load("sqlite:betaapp.db");
+			const adapter = db as unknown as DbAdapter;
+			await runMigrations(adapter);
+			return adapter;
+		})();
 	}
-	return _db;
+	return _dbReady;
 }
 
 type Migration = (db: DbAdapter) => Promise<void>;
@@ -378,16 +386,26 @@ const migrations: Migration[] = [
 
 	// v15: server_updated_at on downloaded_regions (#31)
 	async (db) => {
-		await db.execute(
-			`ALTER TABLE downloaded_regions ADD COLUMN server_updated_at TEXT`,
+		const cols = await db.select<{ name: string }[]>(
+			`PRAGMA table_info(downloaded_regions)`,
 		);
+		if (!cols.some((c) => c.name === "server_updated_at")) {
+			await db.execute(
+				`ALTER TABLE downloaded_regions ADD COLUMN server_updated_at TEXT`,
+			);
+		}
 	},
 
 	// v16: add pointer_dir to climb_image_pins (#38)
 	async (db) => {
-		await db.execute(
-			`ALTER TABLE climb_image_pins ADD COLUMN pointer_dir TEXT NOT NULL DEFAULT 'bottom'`,
+		const cols = await db.select<{ name: string }[]>(
+			`PRAGMA table_info(climb_image_pins)`,
 		);
+		if (!cols.some((c) => c.name === "pointer_dir")) {
+			await db.execute(
+				`ALTER TABLE climb_image_pins ADD COLUMN pointer_dir TEXT NOT NULL DEFAULT 'bottom'`,
+			);
+		}
 	},
 ];
 


### PR DESCRIPTION
…ent ALTER TABLE, bad column name

- Add offline/error status split in sync store; SyncStatus shows WifiOff for no network vs AlertCircle for real errors, with retry button
- Fix getDb() race condition: _dbReady promise ensures all callers wait for migrations to complete before any query runs
- Make v15 and v16 migrations idempotent (PRAGMA table_info guard) to survive devices whose schema_version was left in a half-migrated state
- Fix checkRegionStaleness and downloadRegion querying regions.updated_at which does not exist; correct column is created_at