### PR TITLE
feat: auto-save move list with debounce and nav guard, closes #58

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,8 @@ GitHub Issues is the task management system for this project (repo: `sethgo88/be
 ### Workflow
 1. Before starting any new work, run `list issues` to check open issues and current priorities
 2. Never start work without a corresponding issue — create one first if it doesn't exist
-3. Reference the issue number in every commit message (e.g. `feat: add route snapping, closes #14`)
-4. When a task is complete, close the issue and leave a brief comment summarising what was done
-5. If work reveals new tasks or edge cases, open new issues rather than expanding scope of the current one
+3. **Before touching any file, create or checkout the branch for the issue.** Run `git branch --show-current`; if on `master`, run `git checkout -b feat/<description>` (or `fix/`, `phase/` as appropriate). If a branch for the issue already exists, check it out instead.
+4. Reference the issue number in every commit message (e.g. `feat: add route snapping, closes #14`)
+5. When a task is complete, close the issue and leave a brief comment summarising what was done
+6. If work reveals new tasks or edge cases, open new issues rather than expanding scope of the current one
 

--- a/src/components/README.md
+++ b/src/components/README.md
@@ -44,11 +44,12 @@ templates   Layout shells with no real data — just children/slots.
 | `ClimbImageViewer` | Fullscreen photo viewer with pin annotation overlay. Read-only shows pins; "Edit pins" mode enables tap-to-place, drag-to-reposition, and per-pin description popovers. Four pin types: LH (blue), RH (red), LF (green), RF (amber). Props: `image` (ClimbImageWithUrl), `onClose`. |
 | `VideoFrameCapturer` | Fullscreen video scrubber for capturing a still frame as a climb image. Auto-opens the device file picker on mount. Shows play/pause + seek bar once a video is loaded; "Save frame" draws the current frame to a canvas, compresses to JPEG, and calls `onCapture(file)`. Props: `onCapture(file)`, `onClose`. |
 | `ImportBetaSheet` | Bottom sheet for importing a move list from plain text (one-per-line) or CSV. Auto-detects CSV when >1 line ends with a comma. Replaces existing moves on import. Props: `climbId`, `isOpen`, `onClose`. |
+| `ConfirmDialog` | Centred modal overlay for confirming destructive or navigating-away actions. Props: `isOpen`, `title`, `message`, `confirmLabel?`, `cancelLabel?`, `onConfirm`, `onCancel`. |
 
 ### Organisms
 | Component | Purpose |
 |---|---|
-| `ClimbForm` | Full add/edit form — used by both `AddClimbView` and `EditClimbView`. Move list is drag-to-reorder via `@dnd-kit/sortable`; long-press the `GripVertical` handle to activate drag (250ms `TouchSensor` delay). |
+| `ClimbForm` | Full add/edit form — used by both `AddClimbView` and `EditClimbView`. Move list is drag-to-reorder via `@dnd-kit/sortable`; long-press the `GripVertical` handle to activate drag (250ms `TouchSensor` delay). Accepts optional `climbId` prop: when provided, moves auto-save after a 1-second debounce via `useUpdateClimbMoves`, shows a Saving/Saved indicator, and blocks navigation while unsaved changes are in-flight using `useBlocker`. |
 | `NavBar` | Bottom navigation bar: Home, Add, Search, Menu |
 | `Drawer` | Slide-up modal sheet |
 

--- a/src/components/molecules/ConfirmDialog.tsx
+++ b/src/components/molecules/ConfirmDialog.tsx
@@ -1,0 +1,42 @@
+import { Button } from "@/components/atoms/Button";
+
+interface ConfirmDialogProps {
+	isOpen: boolean;
+	title: string;
+	message: string;
+	confirmLabel?: string;
+	cancelLabel?: string;
+	onConfirm: () => void;
+	onCancel: () => void;
+}
+
+export function ConfirmDialog({
+	isOpen,
+	title,
+	message,
+	confirmLabel = "Leave",
+	cancelLabel = "Stay",
+	onConfirm,
+	onCancel,
+}: ConfirmDialogProps) {
+	if (!isOpen) return null;
+
+	return (
+		<div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4">
+			<div className="w-full max-w-sm rounded-card bg-surface-raised p-5 flex flex-col gap-4 shadow-card">
+				<div>
+					<p className="font-semibold text-text-primary">{title}</p>
+					<p className="text-sm text-text-secondary mt-1">{message}</p>
+				</div>
+				<div className="flex gap-2">
+					<Button variant="outlined" className="flex-1" onClick={onCancel}>
+						{cancelLabel}
+					</Button>
+					<Button variant="primary" className="flex-1" onClick={onConfirm}>
+						{confirmLabel}
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/components/organisms/ClimbForm.tsx
+++ b/src/components/organisms/ClimbForm.tsx
@@ -15,13 +15,16 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { useForm, uuid } from "@tanstack/react-form";
+import { useBlocker } from "@tanstack/react-router";
 import { GripVertical } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/atoms/Button";
 import { Input } from "@/components/atoms/Input";
 import { Select } from "@/components/atoms/Select";
 import { ToggleGroup } from "@/components/atoms/ToggleGroup";
+import { ConfirmDialog } from "@/components/molecules/ConfirmDialog";
 import { ImportBetaSheet } from "@/components/molecules/ImportBetaSheet";
+import { useUpdateClimbMoves } from "@/features/climbs/climbs.queries";
 import {
 	ClimbFormSchema,
 	type ClimbFormValues,
@@ -90,12 +93,20 @@ const SortableMoveRow = ({
 
 // ── Climb form ────────────────────────────────────────────────────────────────
 
+type SaveStatus = "idle" | "saving" | "saved";
+
 interface ClimbFormProps {
 	defaultValues?: Partial<ClimbFormValues>;
 	onSubmit: (values: ClimbFormValues) => Promise<void>;
+	/** When provided, moves are auto-saved after a 1-second debounce. */
+	climbId?: string;
 }
 
-export const ClimbForm = ({ defaultValues, onSubmit }: ClimbFormProps) => {
+export const ClimbForm = ({
+	defaultValues,
+	onSubmit,
+	climbId,
+}: ClimbFormProps) => {
 	const [movesList, setMovesList] = useState<MoveItem[]>(() => {
 		if (defaultValues?.moves) {
 			try {
@@ -111,6 +122,13 @@ export const ClimbForm = ({ defaultValues, onSubmit }: ClimbFormProps) => {
 		defaultValues?.route_type ?? "sport",
 	);
 	const [importOpen, setImportOpen] = useState(false);
+	const [isDirty, setIsDirty] = useState(false);
+	const [saveStatus, setSaveStatus] = useState<SaveStatus>("idle");
+
+	const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const savedStatusRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const isFirstRender = useRef(true);
+	const updateMoves = useUpdateClimbMoves();
 
 	const inputRefs = useRef<Array<HTMLTextAreaElement | null>>([]);
 
@@ -198,6 +216,50 @@ export const ClimbForm = ({ defaultValues, onSubmit }: ClimbFormProps) => {
 		}
 	}, [movesList.length]);
 
+	// ── Auto-save moves (edit mode only) ──────────────────────────────────────
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: updateMoves.mutate is stable from useMutation
+	useEffect(() => {
+		if (!climbId) return;
+		if (isFirstRender.current) {
+			isFirstRender.current = false;
+			return;
+		}
+		setIsDirty(true);
+		setSaveStatus("idle");
+		if (debounceRef.current) clearTimeout(debounceRef.current);
+		debounceRef.current = setTimeout(() => {
+			setSaveStatus("saving");
+			updateMoves.mutate(
+				{ id: climbId, moves: JSON.stringify(movesList) },
+				{
+					onSuccess: () => {
+						setIsDirty(false);
+						setSaveStatus("saved");
+						if (savedStatusRef.current) clearTimeout(savedStatusRef.current);
+						savedStatusRef.current = setTimeout(
+							() => setSaveStatus("idle"),
+							2000,
+						);
+					},
+					onError: () => {
+						setSaveStatus("idle");
+					},
+				},
+			);
+		}, 1000);
+		return () => {
+			if (debounceRef.current) clearTimeout(debounceRef.current);
+		};
+	}, [movesList, climbId]);
+
+	// ── Navigation guard ──────────────────────────────────────────────────────
+
+	const blocker = useBlocker({
+		shouldBlockFn: () => !!climbId && isDirty,
+		withResolver: true,
+	});
+
 	// ── Form ──────────────────────────────────────────────────────────────────
 
 	const { data: grades = [] } = useGrades(routeType);
@@ -228,6 +290,9 @@ export const ClimbForm = ({ defaultValues, onSubmit }: ClimbFormProps) => {
 				alert(messages);
 				return;
 			}
+			// Cancel any pending auto-save; full save covers the moves too.
+			if (debounceRef.current) clearTimeout(debounceRef.current);
+			setIsDirty(false);
 			await onSubmit(parsed.data);
 		},
 	});
@@ -339,6 +404,11 @@ export const ClimbForm = ({ defaultValues, onSubmit }: ClimbFormProps) => {
 			</div>
 
 			<div className="w-full rounded-md bg-surface-card p-2 overflow-y-scroll">
+				{climbId && saveStatus !== "idle" && (
+					<p className="text-xs text-text-secondary mb-2 px-1">
+						{saveStatus === "saving" ? "Saving…" : "Saved"}
+					</p>
+				)}
 				<DndContext
 					sensors={sensors}
 					collisionDetection={closestCenter}
@@ -363,6 +433,16 @@ export const ClimbForm = ({ defaultValues, onSubmit }: ClimbFormProps) => {
 					</SortableContext>
 				</DndContext>
 			</div>
+
+			<ConfirmDialog
+				isOpen={blocker.status === "blocked"}
+				title="Unsaved changes"
+				message="You have unsaved changes. Leave anyway?"
+				confirmLabel="Leave"
+				cancelLabel="Stay"
+				onConfirm={() => blocker.proceed?.()}
+				onCancel={() => blocker.reset?.()}
+			/>
 		</form>
 	);
 };

--- a/src/views/EditClimbView.tsx
+++ b/src/views/EditClimbView.tsx
@@ -142,6 +142,7 @@ const EditClimbView = () => {
 	return (
 		<div className="flex flex-col gap-4">
 			<ClimbForm
+				climbId={climbId}
 				defaultValues={{
 					name: climb.name,
 					route_type: climb.route_type as "sport" | "boulder",


### PR DESCRIPTION
- Add ConfirmDialog molecule for navigation-block confirmation
- ClimbForm accepts optional climbId prop enabling 1s debounced auto-save via useUpdateClimbMoves, Saving/Saved indicator, and useBlocker guard
- EditClimbView passes climbId to ClimbForm to activate auto-save mode
- Update component README docs