### PR TITLE
feat: full location breadcrumb, remove swipe-to-delete, add delete in detail view, closes #44

### DIFF
--- a/src/components/molecules/ClimbCard.tsx
+++ b/src/components/molecules/ClimbCard.tsx
@@ -1,5 +1,3 @@
-import { Trash2 } from "lucide-react";
-import { useState } from "react";
 import type { Climb } from "@/features/climbs/climbs.schema";
 import { cn } from "@/lib/cn";
 import { buildLocationString } from "@/utils/build-location-string";
@@ -7,12 +5,9 @@ import { buildLocationString } from "@/utils/build-location-string";
 interface ClimbCardProps {
 	climb: Climb;
 	onClick: () => void;
-	onDelete?: (id: string) => Promise<void>;
 }
 
-export const ClimbCard = ({ climb, onClick, onDelete }: ClimbCardProps) => {
-	const [showDelete, setShowDelete] = useState(false);
-
+export const ClimbCard = ({ climb, onClick }: ClimbCardProps) => {
 	return (
 		<li
 			className={cn(
@@ -31,45 +26,15 @@ export const ClimbCard = ({ climb, onClick, onDelete }: ClimbCardProps) => {
 					<span className="font-display text-sm">{climb.grade}</span>
 				</div>
 				<div className="text-xs text-current/70">
-					{buildLocationString([climb.country, climb.area, climb.sub_area])}
+					{buildLocationString([
+						climb.country,
+						climb.area,
+						climb.sub_area,
+						climb.crag,
+						climb.wall,
+					])}
 				</div>
 			</button>
-
-			{onDelete && (
-				<>
-					<button
-						type="button"
-						className="p-2.5 text-text-secondary"
-						onClick={() => setShowDelete(true)}
-					>
-						<Trash2 size={16} />
-					</button>
-					<div
-						className={cn(
-							"absolute grid h-full w-full cursor-pointer grid-cols-2 bg-surface-card text-center text-xl font-bold transition-all duration-200 top-0",
-							showDelete ? "left-0" : "left-full",
-						)}
-					>
-						<button
-							type="button"
-							className="bg-orange-700/40 text-amber-900 flex justify-center items-center"
-							onClick={() => {
-								onDelete(climb.id);
-								setShowDelete(false);
-							}}
-						>
-							<span>Delete</span>
-						</button>
-						<button
-							type="button"
-							className="bg-zinc-700/40 text-zinc-700 flex justify-center items-center"
-							onClick={() => setShowDelete(false)}
-						>
-							<span>Cancel</span>
-						</button>
-					</div>
-				</>
-			)}
 		</li>
 	);
 };

--- a/src/features/climbs/README.md
+++ b/src/features/climbs/README.md
@@ -22,6 +22,8 @@ ClimbSchema = {
   country?: string
   area?: string
   sub_area?: string
+  crag?: string
+  wall?: string
   route_location?: string
   link?: string
   route_id?: string      // optional link to routes_cache
@@ -50,6 +52,8 @@ CREATE TABLE IF NOT EXISTS climbs (
     country          TEXT,
     area             TEXT,
     sub_area         TEXT,
+    crag             TEXT,
+    wall             TEXT,
     route_location   TEXT,
     link             TEXT,
     route_id         TEXT,
@@ -136,7 +140,7 @@ Soft-deleted rows are included in sync pushes so Supabase receives the `deleted_
 public.climbs (
   id uuid pk,  user_id uuid,  name text,  route_type text,
   grade text,  moves text,  sent_status text,
-  country text,  area text,  sub_area text,  route_location text,  link text,
+  country text,  area text,  sub_area text,  crag text,  wall text,  route_location text,  link text,
   route_id uuid references public.routes,
   created_at timestamptz,  updated_at timestamptz,  deleted_at timestamptz
 )

--- a/src/features/climbs/climbs.schema.ts
+++ b/src/features/climbs/climbs.schema.ts
@@ -24,6 +24,8 @@ export const ClimbSchema = z.object({
 	country: z.string().optional(),
 	area: z.string().optional(),
 	sub_area: z.string().optional(),
+	crag: z.string().optional(),
+	wall: z.string().optional(),
 	route_location: z.string().optional(),
 	link: z.string().optional(),
 	route_id: z.string().nullable().optional(),
@@ -43,6 +45,8 @@ export const ClimbFormSchema = z.object({
 	country: z.string().optional(),
 	area: z.string().optional(),
 	sub_area: z.string().optional(),
+	crag: z.string().optional(),
+	wall: z.string().optional(),
 	route_location: z.string().optional(),
 	link: z.string().optional(),
 });

--- a/src/features/climbs/climbs.service.ts
+++ b/src/features/climbs/climbs.service.ts
@@ -26,8 +26,8 @@ export async function insertClimb(
 	const db = await getDb();
 	const id = crypto.randomUUID();
 	await db.execute(
-		`INSERT INTO climbs (id, user_id, name, route_type, grade, moves, sent_status, country, area, sub_area, route_location, link, route_id)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO climbs (id, user_id, name, route_type, grade, moves, sent_status, country, area, sub_area, crag, wall, route_location, link, route_id)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		[
 			id,
 			userId,
@@ -39,6 +39,8 @@ export async function insertClimb(
 			data.country ?? null,
 			data.area ?? null,
 			data.sub_area ?? null,
+			data.crag ?? null,
+			data.wall ?? null,
 			data.route_location ?? null,
 			data.link ?? null,
 			routeId ?? null,
@@ -55,7 +57,7 @@ export async function updateClimb(
 	await db.execute(
 		`UPDATE climbs
      SET name = ?, route_type = ?, grade = ?, moves = ?, sent_status = ?,
-         country = ?, area = ?, sub_area = ?, route_location = ?, link = ?, route_id = ?
+         country = ?, area = ?, sub_area = ?, crag = ?, wall = ?, route_location = ?, link = ?, route_id = ?
      WHERE id = ? AND deleted_at IS NULL`,
 		[
 			data.name,
@@ -66,6 +68,8 @@ export async function updateClimb(
 			data.country ?? null,
 			data.area ?? null,
 			data.sub_area ?? null,
+			data.crag ?? null,
+			data.wall ?? null,
 			data.route_location ?? null,
 			data.link ?? null,
 			routeId ?? null,
@@ -112,9 +116,9 @@ export async function applyRemoteClimb(climb: Climb): Promise<void> {
 	await db.execute(
 		`INSERT OR REPLACE INTO climbs
      (id, user_id, name, route_type, grade, moves, sent_status,
-      country, area, sub_area, route_location, link, route_id,
+      country, area, sub_area, crag, wall, route_location, link, route_id,
       created_at, updated_at, deleted_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		[
 			climb.id,
 			climb.user_id,
@@ -126,6 +130,8 @@ export async function applyRemoteClimb(climb: Climb): Promise<void> {
 			climb.country ?? null,
 			climb.area ?? null,
 			climb.sub_area ?? null,
+			climb.crag ?? null,
+			climb.wall ?? null,
 			climb.route_location ?? null,
 			climb.link ?? null,
 			climb.route_id ?? null,

--- a/src/features/sync/sync.service.ts
+++ b/src/features/sync/sync.service.ts
@@ -86,9 +86,9 @@ export async function pullClimbs(
 		await db.execute(
 			`INSERT OR REPLACE INTO climbs
        (id, user_id, name, route_type, grade, moves, sent_status,
-        country, area, sub_area, route_location, link, route_id,
+        country, area, sub_area, crag, wall, route_location, link, route_id,
         created_at, updated_at, deleted_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			[
 				row.id,
 				row.user_id,
@@ -100,6 +100,8 @@ export async function pullClimbs(
 				row.country ?? null,
 				row.area ?? null,
 				row.sub_area ?? null,
+				row.crag ?? null,
+				row.wall ?? null,
 				row.route_location ?? null,
 				row.link ?? null,
 				row.route_id ?? null,

--- a/src/lib/README.md
+++ b/src/lib/README.md
@@ -64,6 +64,7 @@ Versioned migration runner. Maintains a `schema_version` table (single row) and 
 | v15 | `server_updated_at` on `downloaded_regions` for staleness detection (#31) |
 | v16 | `pointer_dir` on `climb_image_pins` (#38) |
 | v17 | Backfill `server_updated_at` on `downloaded_regions` for devices that skipped v15 |
+| v18 | `crag`, `wall` on `climbs` — full 5-level location breadcrumb (#44) |
 
 ### Rules
 - Always use `?` positional parameters — never string interpolation (SQL injection)

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -420,6 +420,20 @@ const migrations: Migration[] = [
 			);
 		}
 	},
+
+	// v18: add crag and wall to climbs (#44)
+	async (db) => {
+		const cols = await db.select<{ name: string }[]>(
+			`PRAGMA table_info(climbs)`,
+		);
+		const names = cols.map((c) => c.name);
+		if (!names.includes("crag")) {
+			await db.execute(`ALTER TABLE climbs ADD COLUMN crag TEXT`);
+		}
+		if (!names.includes("wall")) {
+			await db.execute(`ALTER TABLE climbs ADD COLUMN wall TEXT`);
+		}
+	},
 ];
 
 export async function runMigrations(db: DbAdapter): Promise<void> {

--- a/src/utils/build-location-string.ts
+++ b/src/utils/build-location-string.ts
@@ -1,3 +1,5 @@
-export const buildLocationString = (locations: Array<string | undefined>) => {
-	return locations.filter((loc) => loc !== "").join(" > ");
+export const buildLocationString = (
+	locations: Array<string | null | undefined>,
+) => {
+	return locations.filter((loc) => loc != null && loc !== "").join(" > ");
 };

--- a/src/views/ClimbDetailView.tsx
+++ b/src/views/ClimbDetailView.tsx
@@ -11,7 +11,7 @@ import {
 	useDeleteBurn,
 	useUpdateBurn,
 } from "@/features/burns/burns.queries";
-import { useClimb } from "@/features/climbs/climbs.queries";
+import { useClimb, useDeleteClimb } from "@/features/climbs/climbs.queries";
 import { useClimbsStore } from "@/features/climbs/climbs.store";
 import { useRoute } from "@/features/routes/routes.queries";
 import { cn } from "@/lib/cn";
@@ -26,8 +26,10 @@ const ClimbDetailView = () => {
 	const addBurn = useAddBurn();
 	const updateBurn = useUpdateBurn();
 	const deleteBurn = useDeleteBurn();
+	const deleteClimb = useDeleteClimb();
 	const setSelectedClimbId = useClimbsStore((s) => s.setSelectedClimbId);
 	const [movesOpen, setMovesOpen] = useState(false);
+	const [confirmDelete, setConfirmDelete] = useState(false);
 	const [burnsOpen, setBurnsOpen] = useState(false);
 	const [showAddBurn, setShowAddBurn] = useState(false);
 	const [addDate, setAddDate] = useState(() =>
@@ -68,6 +70,8 @@ const ClimbDetailView = () => {
 		climb.country,
 		climb.area,
 		climb.sub_area,
+		climb.crag,
+		climb.wall,
 	]);
 
 	return (
@@ -150,6 +154,28 @@ const ClimbDetailView = () => {
 			</Button>
 
 			{/* Burns section */}
+
+			{confirmDelete ? (
+				<div className="flex gap-2">
+					<Button variant="outlined" onClick={() => setConfirmDelete(false)}>
+						Cancel
+					</Button>
+					<Button
+						onClick={() => {
+							deleteClimb.mutate(climb.id, {
+								onSuccess: () => navigate({ to: "/" }),
+							});
+						}}
+						disabled={deleteClimb.isPending}
+					>
+						Confirm Delete
+					</Button>
+				</div>
+			) : (
+				<Button variant="outlined" onClick={() => setConfirmDelete(true)}>
+					Delete
+				</Button>
+			)}
 			<div className="rounded-md bg-surface-card">
 				<button
 					type="button"

--- a/src/views/HomeView.tsx
+++ b/src/views/HomeView.tsx
@@ -3,13 +3,12 @@ import { Input } from "@/components/atoms/Input";
 import { Spinner } from "@/components/atoms/Spinner";
 import { ClimbCard } from "@/components/molecules/ClimbCard";
 import { FilterPanel } from "@/components/molecules/FilterPanel";
-import { useClimbs, useDeleteClimb } from "@/features/climbs/climbs.queries";
+import { useClimbs } from "@/features/climbs/climbs.queries";
 import { useClimbsStore } from "@/features/climbs/climbs.store";
 
 const HomeView = () => {
 	const navigate = useNavigate();
 	const { data: climbs = [], isLoading } = useClimbs();
-	const { mutateAsync: deleteClimb } = useDeleteClimb();
 
 	const searchText = useClimbsStore((s) => s.searchText);
 	const setSearchText = useClimbsStore((s) => s.setSearchText);
@@ -29,7 +28,7 @@ const HomeView = () => {
 		if (!statusFilters.has(c.sent_status)) return false;
 		if (!typeFilters.has(c.route_type)) return false;
 		if (query) {
-			const haystack = [c.name, c.grade, c.country, c.area, c.sub_area]
+			const haystack = [c.name, c.grade, c.country, c.area, c.sub_area, c.crag, c.wall]
 				.filter(Boolean)
 				.join(" ")
 				.toLowerCase();
@@ -57,7 +56,6 @@ const HomeView = () => {
 								params: { climbId: climb.id },
 							})
 						}
-						onDelete={deleteClimb}
 					/>
 				))}
 				{filtered.length === 0 && (


### PR DESCRIPTION
- Add crag and wall fields to climbs schema, SQLite (v18 migration), service, and sync
- Update buildLocationString to filter null/undefined in addition to empty string
- ClimbCard: show Country > Region > Sub-region > Crag > Wall breadcrumb; remove swipe-to-delete and onDelete prop
- ClimbDetailView: 5-level breadcrumb + Delete button with inline confirmation; navigates to home on success
- HomeView: remove deleteClimb usage; include crag/wall in search haystack
- Docs: update features/climbs README and lib README migration history

https://claude.ai/code/session_01WLet7b8RQxeFLpDgv7AkNo