### PR TITLE
feat: auto-verify location submissions for admins, closes #55

### DIFF
--- a/src/features/locations/README.md
+++ b/src/features/locations/README.md
@@ -99,11 +99,11 @@ If any level has no data, the download still completes and records the region as
 
 | Function | What it does |
 |---|---|
-| `submitSubRegion(values, userId)` | Inserts into Supabase `sub_regions` with `status='pending'` + local cache |
-| `submitCrag(values, userId)` | Inserts into Supabase `crags` with `status='pending'` + local cache |
-| `submitWall(values, userId)` | Inserts into Supabase `walls` with `status='pending'` + local cache |
+| `submitSubRegion(values, userId, isAdmin)` | Inserts into Supabase `sub_regions` with `status='verified'` (admin) or `status='pending'` (user) + local cache |
+| `submitCrag(values, userId, isAdmin)` | Inserts into Supabase `crags` with `status='verified'` (admin) or `status='pending'` (user) + local cache |
+| `submitWall(values, userId, isAdmin)` | Inserts into Supabase `walls` with `status='verified'` (admin) or `status='pending'` (user) + local cache |
 
-Pending items are visible immediately to the submitting user; hidden from others until admin verifies.
+Admin submissions are auto-verified and immediately visible to all users. Non-admin submissions remain pending until an admin verifies them.
 
 ### Admin location verification (Supabase + local cache)
 

--- a/src/features/locations/locations.queries.ts
+++ b/src/features/locations/locations.queries.ts
@@ -340,9 +340,10 @@ export function useAdminDeleteRegion() {
 export function useSubmitSubRegion() {
 	const qc = useQueryClient();
 	const userId = useAuthStore((s) => s.user?.id ?? "");
+	const isAdmin = useAuthStore((s) => s.user?.role === "admin");
 	return useMutation({
 		mutationFn: (values: SubRegionSubmitValues) =>
-			submitSubRegion(values, userId),
+			submitSubRegion(values, userId, isAdmin),
 		onSuccess: (_data, values) => {
 			qc.invalidateQueries({ queryKey: ["sub_regions", values.region_id] });
 		},
@@ -352,8 +353,9 @@ export function useSubmitSubRegion() {
 export function useSubmitCrag() {
 	const qc = useQueryClient();
 	const userId = useAuthStore((s) => s.user?.id ?? "");
+	const isAdmin = useAuthStore((s) => s.user?.role === "admin");
 	return useMutation({
-		mutationFn: (values: CragSubmitValues) => submitCrag(values, userId),
+		mutationFn: (values: CragSubmitValues) => submitCrag(values, userId, isAdmin),
 		onSuccess: (_data, values) => {
 			qc.invalidateQueries({
 				queryKey: ["crags", values.sub_region_id],
@@ -365,8 +367,9 @@ export function useSubmitCrag() {
 export function useSubmitWall() {
 	const qc = useQueryClient();
 	const userId = useAuthStore((s) => s.user?.id ?? "");
+	const isAdmin = useAuthStore((s) => s.user?.role === "admin");
 	return useMutation({
-		mutationFn: (values: WallSubmitValues) => submitWall(values, userId),
+		mutationFn: (values: WallSubmitValues) => submitWall(values, userId, isAdmin),
 		onSuccess: (_data, values) => {
 			qc.invalidateQueries({ queryKey: ["walls", values.crag_id] });
 		},

--- a/src/features/locations/locations.service.ts
+++ b/src/features/locations/locations.service.ts
@@ -405,36 +405,40 @@ export async function downloadRegion(regionId: string): Promise<void> {
 export async function submitSubRegion(
 	values: SubRegionSubmitValues,
 	userId: string,
+	isAdmin = false,
 ): Promise<void> {
 	const id = crypto.randomUUID();
+	const status = isAdmin ? "verified" : "pending";
 	const { error } = await supabase.from("sub_regions").insert({
 		id,
 		region_id: values.region_id,
 		name: values.name,
 		sort_order: 9999,
-		status: "pending",
+		status,
 		created_by: userId,
 	});
 	if (error) throw error;
 
 	const db = await getDb();
 	await db.execute(
-		"INSERT INTO sub_regions_cache (id, region_id, name, sort_order, status, created_by, created_at) VALUES (?, ?, ?, 9999, 'pending', ?, datetime('now'))",
-		[id, values.region_id, values.name, userId],
+		"INSERT INTO sub_regions_cache (id, region_id, name, sort_order, status, created_by, created_at) VALUES (?, ?, ?, 9999, ?, ?, datetime('now'))",
+		[id, values.region_id, values.name, status, userId],
 	);
 }
 
 export async function submitCrag(
 	values: CragSubmitValues,
 	userId: string,
+	isAdmin = false,
 ): Promise<void> {
 	const id = crypto.randomUUID();
+	const status = isAdmin ? "verified" : "pending";
 	const { error } = await supabase.from("crags").insert({
 		id,
 		sub_region_id: values.sub_region_id,
 		name: values.name,
 		sort_order: 9999,
-		status: "pending",
+		status,
 		created_by: userId,
 		lat: values.lat ?? null,
 		lng: values.lng ?? null,
@@ -443,11 +447,12 @@ export async function submitCrag(
 
 	const db = await getDb();
 	await db.execute(
-		"INSERT INTO crags_cache (id, sub_region_id, name, sort_order, status, created_by, created_at, lat, lng) VALUES (?, ?, ?, 9999, 'pending', ?, datetime('now'), ?, ?)",
+		"INSERT INTO crags_cache (id, sub_region_id, name, sort_order, status, created_by, created_at, lat, lng) VALUES (?, ?, ?, 9999, ?, ?, datetime('now'), ?, ?)",
 		[
 			id,
 			values.sub_region_id,
 			values.name,
+			status,
 			userId,
 			values.lat ?? null,
 			values.lng ?? null,
@@ -458,8 +463,10 @@ export async function submitCrag(
 export async function submitWall(
 	values: WallSubmitValues,
 	userId: string,
+	isAdmin = false,
 ): Promise<void> {
 	const id = crypto.randomUUID();
+	const status = isAdmin ? "verified" : "pending";
 	// biome-ignore lint/suspicious/noExplicitAny: wall_type not yet in generated Supabase types
 	const { error } = await (supabase.from("walls") as any).insert({
 		id,
@@ -469,18 +476,19 @@ export async function submitWall(
 		lat: values.lat ?? null,
 		lng: values.lng ?? null,
 		sort_order: 9999,
-		status: "pending",
+		status,
 		created_by: userId,
 	});
 	if (error) throw error;
 
 	const db = await getDb();
 	await db.execute(
-		"INSERT INTO walls_cache (id, crag_id, name, sort_order, status, created_by, created_at, lat, lng, wall_type) VALUES (?, ?, ?, 9999, 'pending', ?, datetime('now'), ?, ?, ?)",
+		"INSERT INTO walls_cache (id, crag_id, name, sort_order, status, created_by, created_at, lat, lng, wall_type) VALUES (?, ?, ?, 9999, ?, ?, datetime('now'), ?, ?, ?)",
 		[
 			id,
 			values.crag_id,
 			values.name,
+			status,
 			userId,
 			values.lat ?? null,
 			values.lng ?? null,


### PR DESCRIPTION
`submitSubRegion`, `submitCrag`, and `submitWall` now accept an `isAdmin`
flag (matching the existing pattern in `addRoute`). Admin submissions set
`status='verified'` directly; non-admin submissions remain `status='pending'`.
The `useSubmit*` query hooks read `isAdmin` from the auth store and pass it
through automatically.

https://claude.ai/code/session_012LobL9TErBP4YRuWFrTH4s