### PR TITLE
feat: add inline route picker to add climb form, closes #51

### DIFF
--- a/src/components/README.md
+++ b/src/components/README.md
@@ -45,11 +45,12 @@ templates   Layout shells with no real data — just children/slots.
 | `VideoFrameCapturer` | Fullscreen video scrubber for capturing a still frame as a climb image. Auto-opens the device file picker on mount. Shows play/pause + seek bar once a video is loaded; "Save frame" draws the current frame to a canvas, compresses to JPEG, and calls `onCapture(file)`. Props: `onCapture(file)`, `onClose`. |
 | `ImportBetaSheet` | Bottom sheet for importing a move list from plain text (one-per-line) or CSV. Auto-detects CSV when >1 line ends with a comma. Replaces existing moves on import. Props: `climbId`, `isOpen`, `onClose`. |
 | `ConfirmDialog` | Centred modal overlay for confirming destructive or navigating-away actions. Props: `isOpen`, `title`, `message`, `confirmLabel?`, `cancelLabel?`, `onConfirm`, `onCancel`. |
+| `RoutePickerSheet` | Full-screen sheet that chains `LocationDrillDown` with a route list (verified routes only for the selected wall). Used in `AddClimbView` to link a log entry to a community route. Props: `isOpen`, `onClose`, `onSelect(route)`. |
 
 ### Organisms
 | Component | Purpose |
 |---|---|
-| `ClimbForm` | Full add/edit form — used by both `AddClimbView` and `EditClimbView`. Move list is drag-to-reorder via `@dnd-kit/sortable`; long-press the `GripVertical` handle to activate drag (250ms `TouchSensor` delay). Accepts optional `climbId` prop: when provided, moves auto-save after a 1-second debounce via `useUpdateClimbMoves`, shows a Saving/Saved indicator, and blocks navigation while unsaved changes are in-flight using `useBlocker`. |
+| `ClimbForm` | Full add/edit form — used by both `AddClimbView` and `EditClimbView`. Move list is drag-to-reorder via `@dnd-kit/sortable`; long-press the `GripVertical` handle to activate drag (250ms `TouchSensor` delay). Accepts optional `climbId` prop: when provided, moves auto-save after a 1-second debounce via `useUpdateClimbMoves`, shows a Saving/Saved indicator, and blocks navigation while unsaved changes are in-flight using `useBlocker`. Accepts optional `linkedRoute`, `onOpenRoutePicker`, `onUnlinkRoute` props for displaying/clearing a linked community route (shown above the Save button). |
 | `NavBar` | Bottom navigation bar: Home, Add, Search, Menu |
 | `Drawer` | Slide-up modal sheet |
 

--- a/src/components/molecules/RoutePickerSheet.tsx
+++ b/src/components/molecules/RoutePickerSheet.tsx
@@ -1,0 +1,76 @@
+import { useState } from "react";
+import { Spinner } from "@/components/atoms/Spinner";
+import {
+	LocationDrillDown,
+	type LocationSelection,
+} from "@/components/molecules/LocationDrillDown";
+import { Sheet } from "@/components/molecules/Sheet";
+import { useRoutes } from "@/features/routes/routes.queries";
+import type { Route } from "@/features/routes/routes.schema";
+
+type Props = {
+	isOpen: boolean;
+	onClose: () => void;
+	onSelect: (route: Route) => void;
+};
+
+export function RoutePickerSheet({ isOpen, onClose, onSelect }: Props) {
+	const [wallId, setWallId] = useState<string | null>(null);
+
+	const { data: routes = [], isLoading } = useRoutes(wallId);
+	const verifiedRoutes = routes.filter((r) => r.status === "verified");
+
+	const handleLocationChange = (selection: LocationSelection) => {
+		setWallId(selection.wallId);
+	};
+
+	const handleSelect = (route: Route) => {
+		onSelect(route);
+		onClose();
+	};
+
+	return (
+		<Sheet isOpen={isOpen} onClose={onClose} title="Link to route">
+			<div className="flex flex-col gap-4">
+				<LocationDrillDown onChange={handleLocationChange} />
+
+				{wallId && isLoading && (
+					<div className="flex justify-center py-4">
+						<Spinner />
+					</div>
+				)}
+
+				{wallId && !isLoading && verifiedRoutes.length === 0 && (
+					<p className="text-sm text-text-secondary">
+						No verified routes on this wall.
+					</p>
+				)}
+
+				{wallId && !isLoading && verifiedRoutes.length > 0 && (
+					<div className="flex flex-col gap-2">
+						{verifiedRoutes.map((route) => (
+							<button
+								key={route.id}
+								type="button"
+								className="rounded-card bg-surface-card p-4 text-left flex items-center justify-between"
+								onClick={() => handleSelect(route)}
+							>
+								<span className="font-medium text-text-primary">
+									{route.name}
+								</span>
+								<div className="flex items-center gap-2">
+									<span className="text-sm text-text-secondary">
+										{route.grade}
+									</span>
+									<span className="text-xs text-text-muted capitalize">
+										{route.route_type}
+									</span>
+								</div>
+							</button>
+						))}
+					</div>
+				)}
+			</div>
+		</Sheet>
+	);
+}

--- a/src/components/organisms/ClimbForm.tsx
+++ b/src/components/organisms/ClimbForm.tsx
@@ -32,6 +32,7 @@ import {
 	type SentStatus,
 } from "@/features/climbs/climbs.schema";
 import { useGrades } from "@/features/grades/grades.queries";
+import type { Route } from "@/features/routes/routes.schema";
 
 type MoveItem = { id: string; text: string };
 
@@ -103,12 +104,21 @@ interface ClimbFormProps {
 	onSubmit: (values: ClimbFormValues) => Promise<void>;
 	/** When provided, moves are auto-saved after a 1-second debounce. */
 	climbId?: string;
+	/** Currently linked community route, shown as a summary card. */
+	linkedRoute?: Pick<Route, "id" | "name" | "grade"> | null;
+	/** Called when the user taps "Link to route" or "Change route". */
+	onOpenRoutePicker?: () => void;
+	/** Called when the user taps "Unlink". */
+	onUnlinkRoute?: () => void;
 }
 
 export const ClimbForm = ({
 	defaultValues,
 	onSubmit,
 	climbId,
+	linkedRoute,
+	onOpenRoutePicker,
+	onUnlinkRoute,
 }: ClimbFormProps) => {
 	const [movesList, setMovesList] = useState<MoveItem[]>(() => {
 		if (defaultValues?.moves) {
@@ -400,6 +410,47 @@ export const ClimbForm = ({
 						/>
 					)}
 				</form.Field>
+
+				{onOpenRoutePicker && (
+					<div className="rounded-card bg-surface-card px-3 py-2.5">
+						{linkedRoute ? (
+							<div className="flex items-center justify-between gap-2">
+								<div className="min-w-0">
+									<p className="text-sm font-medium text-text-primary truncate">
+										{linkedRoute.name}
+									</p>
+									<p className="text-xs text-text-secondary">
+										{linkedRoute.grade}
+									</p>
+								</div>
+								<div className="flex items-center gap-3 shrink-0">
+									<button
+										type="button"
+										onClick={onOpenRoutePicker}
+										className="text-xs text-accent-primary"
+									>
+										Change
+									</button>
+									<button
+										type="button"
+										onClick={() => onUnlinkRoute?.()}
+										className="text-xs text-text-muted"
+									>
+										Unlink
+									</button>
+								</div>
+							</div>
+						) : (
+							<button
+								type="button"
+								onClick={onOpenRoutePicker}
+								className="text-sm text-text-secondary w-full text-left"
+							>
+								+ Link to route
+							</button>
+						)}
+					</div>
+				)}
 
 				<Button
 					type="submit"

--- a/src/views/AddClimbView.tsx
+++ b/src/views/AddClimbView.tsx
@@ -1,7 +1,10 @@
 import { useNavigate, useSearch } from "@tanstack/react-router";
+import { useState } from "react";
+import { RoutePickerSheet } from "@/components/molecules/RoutePickerSheet";
 import { ClimbForm } from "@/components/organisms/ClimbForm";
 import { useAddClimb } from "@/features/climbs/climbs.queries";
 import type { ClimbFormValues } from "@/features/climbs/climbs.schema";
+import type { Route } from "@/features/routes/routes.schema";
 import { useUiStore } from "@/stores/ui.store";
 
 const AddClimbView = () => {
@@ -12,21 +15,47 @@ const AddClimbView = () => {
 		from: "/climbs/add",
 	});
 
+	const [pickerOpen, setPickerOpen] = useState(false);
+	const [linkedRoute, setLinkedRoute] = useState<{
+		id: string;
+		name: string;
+		grade: string;
+	} | null>(
+		routeId && routeName
+			? { id: routeId, name: routeName, grade: grade ?? "" }
+			: null,
+	);
+
+	const handleRouteSelect = (route: Route) => {
+		setLinkedRoute({ id: route.id, name: route.name, grade: route.grade });
+	};
+
 	const handleSubmit = async (values: ClimbFormValues) => {
-		await addClimb({ data: values, routeId });
+		await addClimb({ data: values, routeId: linkedRoute?.id });
 		addToast({ message: "Climb added", type: "success" });
 		navigate({ to: "/" });
 	};
 
 	return (
-		<ClimbForm
-			defaultValues={{
-				name: routeName ?? "",
-				grade: grade ?? "",
-				route_type: routeType ?? "sport",
-			}}
-			onSubmit={handleSubmit}
-		/>
+		<>
+			<ClimbForm
+				defaultValues={{
+					name: routeName ?? "",
+					grade: grade ?? "",
+					route_type: routeType ?? "sport",
+				}}
+				onSubmit={handleSubmit}
+				linkedRoute={linkedRoute}
+				onOpenRoutePicker={() => setPickerOpen(true)}
+				onUnlinkRoute={() => setLinkedRoute(null)}
+			/>
+
+			<RoutePickerSheet
+				isOpen={pickerOpen}
+				onClose={() => setPickerOpen(false)}
+				onSelect={handleRouteSelect}
+			/>
+		</>
 	);
 };
 


### PR DESCRIPTION
- New RoutePickerSheet molecule: full-screen Sheet that chains LocationDrillDown (country→region→sub-region→crag→wall) with a verified-only route list and a loading spinner
- ClimbForm gains optional linkedRoute / onOpenRoutePicker / onUnlinkRoute props; renders a summary card above the Save button
- AddClimbView manages linked route state (initialised from existing routeId search param for backwards compatibility) and wires the sheet