### PR TITLE
feat: add default sort and sort options to climb list, closes #53

### DIFF
--- a/src/components/molecules/FilterPanel.tsx
+++ b/src/components/molecules/FilterPanel.tsx
@@ -1,6 +1,7 @@
 import { ChevronDown } from "lucide-react";
 import type { Climb } from "@/features/climbs/climbs.schema";
 import { useClimbsStore } from "@/features/climbs/climbs.store";
+import type { SortKey } from "@/features/climbs/climbs.store";
 import { cn } from "@/lib/cn";
 
 interface FilterPanelProps {
@@ -31,6 +32,15 @@ const FilterCheckbox = ({
 	</label>
 );
 
+const SORT_OPTIONS: { key: SortKey; label: string }[] = [
+	{ key: "name_asc", label: "A → Z (title)" },
+	{ key: "name_desc", label: "Z → A (title)" },
+	{ key: "date_desc", label: "Newest first" },
+	{ key: "date_asc", label: "Oldest first" },
+	{ key: "grade_asc", label: "Grade easy → hard" },
+	{ key: "grade_desc", label: "Grade hard → easy" },
+];
+
 export const FilterPanel = ({ climbs }: FilterPanelProps) => {
 	const filtersOpen = useClimbsStore((s) => s.filtersOpen);
 	const setFiltersOpen = useClimbsStore((s) => s.setFiltersOpen);
@@ -38,6 +48,8 @@ export const FilterPanel = ({ climbs }: FilterPanelProps) => {
 	const toggleStatusFilter = useClimbsStore((s) => s.toggleStatusFilter);
 	const typeFilters = useClimbsStore((s) => s.typeFilters);
 	const toggleTypeFilter = useClimbsStore((s) => s.toggleTypeFilter);
+	const sortKey = useClimbsStore((s) => s.sortKey);
+	const setSortKey = useClimbsStore((s) => s.setSortKey);
 
 	// Status counts are filtered by active type filters
 	const typeFiltered = climbs.filter((c) => typeFilters.has(c.route_type));
@@ -60,7 +72,7 @@ export const FilterPanel = ({ climbs }: FilterPanelProps) => {
 				className="flex items-center gap-1 text-sm text-text-secondary w-full"
 				onClick={() => setFiltersOpen(!filtersOpen)}
 			>
-				<span>Filters</span>
+				<span>Filter / Sort</span>
 				<ChevronDown
 					size={16}
 					className={cn("transition-transform", filtersOpen && "rotate-180")}
@@ -111,6 +123,29 @@ export const FilterPanel = ({ climbs }: FilterPanelProps) => {
 								checked={typeFilters.has("boulder")}
 								onChange={() => toggleTypeFilter("boulder")}
 							/>
+						</div>
+					</div>
+					<div>
+						<p className="text-xs text-text-secondary uppercase tracking-wide mb-1">
+							Sort
+						</p>
+						<div className="flex flex-col gap-1">
+							{SORT_OPTIONS.map((opt) => (
+								<label
+									key={opt.key}
+									className="flex items-center gap-2 text-sm cursor-pointer"
+								>
+									<input
+										type="radio"
+										name="sort"
+										value={opt.key}
+										checked={sortKey === opt.key}
+										onChange={() => setSortKey(opt.key)}
+										className="accent-accent-primary w-4 h-4"
+									/>
+									<span>{opt.label}</span>
+								</label>
+							))}
 						</div>
 					</div>
 				</div>

--- a/src/features/climbs/README.md
+++ b/src/features/climbs/README.md
@@ -70,7 +70,7 @@ CREATE TABLE IF NOT EXISTS climbs (
 
 | Function | What it does |
 |---|---|
-| `fetchClimbs(userId)` | All active climbs for user, newest first |
+| `fetchClimbs(userId, sortKey?)` | All active climbs for user; sort defaults to `name_asc`. Grade sort joins `grades_cache` to rank by `sort_order`. |
 | `fetchClimb(id)` | Single climb by id |
 | `backfillClimbLocations()` | One-time startup migration: fills `country/area/sub_area/crag/wall` on route-linked climbs that have empty location data, by joining the local location cache hierarchy |
 | `insertClimb(userId, data, routeId?)` | Creates new climb; when `routeId` is provided, location fields are auto-populated from the route's wall→crag→sub_region→region→country hierarchy |
@@ -88,7 +88,7 @@ CREATE TABLE IF NOT EXISTS climbs (
 
 | Hook | Returns |
 |---|---|
-| `useClimbs()` | All active climbs for current user |
+| `useClimbs()` | All active climbs for current user, sorted per `sortKey` from `useClimbsStore` |
 | `useClimb(id)` | Single climb |
 | `useAddClimb()` | Mutation — `{ data, routeId? }` — inserts + silent push |
 | `useUpdateClimb()` | Mutation — `{ id, data, routeId? }` — updates + silent push |
@@ -103,11 +103,16 @@ After each mutation a **silent push** fires: `pushClimbs(userId)` runs in the ba
 ## climbs.store.ts
 
 ```ts
+type SortKey =
+  | 'name_asc' | 'name_desc'    // alphabetical by climb title
+  | 'date_desc' | 'date_asc'    // by created_at
+  | 'grade_asc' | 'grade_desc'  // by grades_cache.sort_order, discipline-grouped
+
 interface ClimbsStore {
   selectedClimbId: string | null
   setSelectedClimbId: (id: string | null) => void
 
-  // Filter state — persists across navigation
+  // Filter / sort state — persists across navigation
   searchText: string
   setSearchText: (text: string) => void
   filtersOpen: boolean
@@ -116,6 +121,8 @@ interface ClimbsStore {
   toggleStatusFilter: (status: string) => void
   typeFilters: Set<string>            // default: sport, boulder
   toggleTypeFilter: (type: string) => void
+  sortKey: SortKey                    // default: name_asc
+  setSortKey: (key: SortKey) => void
 }
 ```
 

--- a/src/features/climbs/climbs.queries.ts
+++ b/src/features/climbs/climbs.queries.ts
@@ -12,14 +12,16 @@ import {
 	updateClimb,
 	updateClimbMoves,
 } from "./climbs.service";
+import { useClimbsStore } from "./climbs.store";
 
 const CLIMBS_KEY = "climbs";
 
 export function useClimbs() {
 	const userId = useAuthStore((s) => s.user?.id);
+	const sortKey = useClimbsStore((s) => s.sortKey);
 	return useQuery({
-		queryKey: [CLIMBS_KEY, userId],
-		queryFn: () => fetchClimbs(userId ?? ""),
+		queryKey: [CLIMBS_KEY, userId, sortKey],
+		queryFn: () => fetchClimbs(userId ?? "", sortKey),
 		enabled: !!userId,
 	});
 }

--- a/src/features/climbs/climbs.service.ts
+++ b/src/features/climbs/climbs.service.ts
@@ -1,5 +1,6 @@
 import { getDb } from "@/lib/db";
 import type { Climb, ClimbFormValues } from "./climbs.schema";
+import type { SortKey } from "./climbs.store";
 
 type LocationBreadcrumb = {
 	country: string | null;
@@ -40,10 +41,41 @@ async function fetchLocationForRoute(
 	);
 }
 
-export async function fetchClimbs(userId: string): Promise<Climb[]> {
+function buildOrderBy(sortKey: SortKey): string {
+	switch (sortKey) {
+		case "name_asc":
+			return "ORDER BY c.name COLLATE NOCASE ASC";
+		case "name_desc":
+			return "ORDER BY c.name COLLATE NOCASE DESC";
+		case "date_desc":
+			return "ORDER BY c.created_at DESC";
+		case "date_asc":
+			return "ORDER BY c.created_at ASC";
+		case "grade_asc":
+			return "ORDER BY c.route_type ASC, COALESCE(g.sort_order, 9999) ASC";
+		case "grade_desc":
+			return "ORDER BY c.route_type ASC, COALESCE(g.sort_order, 9999) DESC";
+	}
+}
+
+export async function fetchClimbs(
+	userId: string,
+	sortKey: SortKey = "name_asc",
+): Promise<Climb[]> {
 	const db = await getDb();
+	const orderBy = buildOrderBy(sortKey);
+	const needsGradeJoin = sortKey === "grade_asc" || sortKey === "grade_desc";
+	if (needsGradeJoin) {
+		return db.select<Climb[]>(
+			`SELECT c.* FROM climbs c
+       LEFT JOIN grades_cache g ON g.discipline = c.route_type AND g.grade = c.grade
+       WHERE c.user_id = ? AND c.deleted_at IS NULL
+       ${orderBy}`,
+			[userId],
+		);
+	}
 	return db.select<Climb[]>(
-		"SELECT * FROM climbs WHERE user_id = ? AND deleted_at IS NULL ORDER BY created_at DESC",
+		`SELECT c.* FROM climbs c WHERE c.user_id = ? AND c.deleted_at IS NULL ${orderBy}`,
 		[userId],
 	);
 }

--- a/src/features/climbs/climbs.store.ts
+++ b/src/features/climbs/climbs.store.ts
@@ -1,10 +1,18 @@
 import { create } from "zustand";
 
+export type SortKey =
+	| "name_asc"
+	| "name_desc"
+	| "date_desc"
+	| "date_asc"
+	| "grade_asc"
+	| "grade_desc";
+
 interface ClimbsStore {
 	selectedClimbId: string | null;
 	setSelectedClimbId: (id: string | null) => void;
 
-	// Filter state — persists across navigation
+	// Filter / sort state — persists across navigation
 	searchText: string;
 	setSearchText: (text: string) => void;
 	filtersOpen: boolean;
@@ -13,6 +21,8 @@ interface ClimbsStore {
 	toggleStatusFilter: (status: string) => void;
 	typeFilters: Set<string>;
 	toggleTypeFilter: (type: string) => void;
+	sortKey: SortKey;
+	setSortKey: (key: SortKey) => void;
 }
 
 export const useClimbsStore = create<ClimbsStore>((set) => ({
@@ -39,4 +49,6 @@ export const useClimbsStore = create<ClimbsStore>((set) => ({
 			else next.add(type);
 			return { typeFilters: next };
 		}),
+	sortKey: "name_asc",
+	setSortKey: (sortKey) => set({ sortKey }),
 }));


### PR DESCRIPTION
- Default sort is A→Z by climb title (name_asc)
- SortKey type added to climbs.store with setSortKey action
- fetchClimbs accepts sortKey param; grade sort joins grades_cache by discipline + sort_order
- useClimbs includes sortKey in query key so results re-fetch on change
- FilterPanel renamed label to "Filter / Sort" and adds a Sort radio group with 6 options

https://claude.ai/code/session_01CcQaPwmXanDsRZmyNS3EWn