### PR TITLE
feat: navigate to route detail after submit, closes #56

### DIFF
--- a/src/features/routes/README.md
+++ b/src/features/routes/README.md
@@ -75,7 +75,7 @@ Only populated when the user downloads a region (see [`locations/README.md`](../
 |---|---|
 | `fetchRoute(id)` | Reads a single route from `routes_cache` by id; returns `null` if not found |
 | `fetchRoutes(wallId)` | Reads `routes_cache` for a wall, ordered by name |
-| `submitRoute(values, userId)` | Inserts into Supabase `routes` (unverified) + local `routes_cache` |
+| `addRoute(values, userId, isAdmin)` | Inserts into Supabase `routes` + local `routes_cache`; returns the new route `id` |
 | `searchVerifiedRoutes(query)` | Full-text search against Supabase `routes` (verified only, limit 10) |
 | `searchLocalRoutes(query)` | LIKE search on local `routes_cache` by name or grade (verified only, limit 30) |
 | `updateRouteDescription(id, description)` | Updates description in Supabase + local cache |

--- a/src/features/routes/routes.service.ts
+++ b/src/features/routes/routes.service.ts
@@ -23,7 +23,7 @@ export async function addRoute(
 	values: RouteSubmitValues,
 	userId: string,
 	isAdmin: boolean,
-): Promise<void> {
+): Promise<string> {
 	const id = crypto.randomUUID();
 	const status = isAdmin ? "verified" : "pending";
 
@@ -55,6 +55,7 @@ export async function addRoute(
 			userId,
 		],
 	);
+	return id;
 }
 
 export async function editRoute(

--- a/src/views/SubmitRouteView.tsx
+++ b/src/views/SubmitRouteView.tsx
@@ -43,12 +43,16 @@ const SubmitRouteView = () => {
 				return;
 			}
 			try {
-				await submitRoute(parsed.data);
+				const newRouteId = await submitRoute(parsed.data);
 				addToast({
 					message: isAdmin ? "Route added" : "Route submitted for review",
 					type: "success",
 				});
-				router.history.back();
+				router.navigate({
+					to: "/routes/$routeId",
+					params: { routeId: newRouteId },
+					replace: true,
+				});
 			} catch {
 				addToast({ message: "Failed to submit route", type: "error" });
 			}


### PR DESCRIPTION
- addRoute now returns the new route id (Promise<string>)
- SubmitRouteView navigates to /routes/$routeId after successful submission using replace:true so the empty form is not left in history
- Back button on RouteDetailView already navigates to /walls/$wallId, so the user returns to the wall rather than the empty submit form

https://claude.ai/code/session_01CcQaPwmXanDsRZmyNS3EWn