### PR TITLE
feat: show submitter email and display name in verification view, clo…

### DIFF
--- a/src/features/routes/README.md
+++ b/src/features/routes/README.md
@@ -20,6 +20,15 @@ RouteSchema = {
   created_at: string
 }
 
+// Admin-only type — not stored in SQLite
+UnverifiedRoute = RouteSchema & {
+  walls: { ... } | null    // nested location breadcrumb
+  submitter?: {
+    email: string
+    display_name: string | null
+  }
+}
+
 RouteSubmitSchema = {
   wall_id: string      // required — must select a wall
   name: string
@@ -93,7 +102,7 @@ Only populated when the user downloads a region (see [`locations/README.md`](../
 
 | Function | What it does |
 |---|---|
-| `fetchUnverifiedRoutes()` | Supabase query — pending routes only with nested location names |
+| `fetchUnverifiedRoutes()` | Supabase query — pending routes only with nested location names; enriches each route with submitter `email` and `display_name` from the `users` table |
 | `fetchAllRoutes()` | Supabase query — all routes (all statuses) with nested location names, ordered by created_at desc |
 | `verifyRoute(id)` | Sets `status = 'verified'` in Supabase + local cache |
 | `rejectRoute(id)` | Sets `status = 'rejected'` in Supabase + local cache (soft — stays visible to creator) |

--- a/src/features/routes/routes.service.ts
+++ b/src/features/routes/routes.service.ts
@@ -145,6 +145,10 @@ export type UnverifiedRoute = {
 			};
 		};
 	} | null;
+	submitter?: {
+		email: string;
+		display_name: string | null;
+	};
 };
 
 export type VerifiedRouteResult = {
@@ -164,7 +168,30 @@ export async function fetchUnverifiedRoutes(): Promise<UnverifiedRoute[]> {
 		.eq("status", "pending")
 		.order("created_at", { ascending: false });
 	if (error) throw error;
-	return (data ?? []) as UnverifiedRoute[];
+
+	const routes = (data ?? []) as UnverifiedRoute[];
+
+	const userIds = [...new Set(routes.map((r) => r.created_by))];
+	if (userIds.length > 0) {
+		const { data: users } = await supabase
+			.from("users")
+			.select("id, email, display_name")
+			.in("id", userIds);
+		if (users) {
+			const userMap = new Map(users.map((u) => [u.id, u]));
+			for (const route of routes) {
+				const user = userMap.get(route.created_by);
+				if (user) {
+					route.submitter = {
+						email: user.email,
+						display_name: user.display_name,
+					};
+				}
+			}
+		}
+	}
+
+	return routes;
 }
 
 export async function fetchAllRoutes(): Promise<UnverifiedRoute[]> {

--- a/src/views/admin/VerificationView.tsx
+++ b/src/views/admin/VerificationView.tsx
@@ -278,6 +278,10 @@ const RouteRow = ({ route }: { route: UnverifiedRoute }) => {
 		);
 	};
 
+	const submitterLabel = route.submitter
+		? (route.submitter.display_name ?? route.submitter.email)
+		: null;
+
 	return (
 		<div className="rounded-lg bg-surface-card p-4 flex flex-col gap-1">
 			<p className="text-xs text-text-secondary">{locationLabel(route)}</p>
@@ -292,6 +296,17 @@ const RouteRow = ({ route }: { route: UnverifiedRoute }) => {
 					{new Date(route.created_at).toLocaleDateString()}
 				</span>
 			</div>
+			{submitterLabel && (
+				<p className="text-xs text-text-secondary">
+					Submitted by{" "}
+					<span className="text-text-primary">{submitterLabel}</span>
+					{route.submitter?.display_name && (
+						<span className="text-text-tertiary ml-1">
+							({route.submitter.email})
+						</span>
+					)}
+				</p>
+			)}
 
 			{mode === "idle" && (
 				<div className="flex gap-2 mt-2 flex-wrap">


### PR DESCRIPTION
…ses #61

Pending route cards now display who submitted the route. The admin verification view enriches each unverified route with the submitter's email and display_name (fetched from the public users table in a single batch query). If a display name is set it appears as the primary label with the email in parentheses; otherwise the email is shown alone.

https://claude.ai/code/session_014rTAE9dgsmoSqaykH9LXnB