### PR TITLE
feat: add personal stats screen with grade, monthly, and burns charts…

### DIFF
--- a/docs/stack.md
+++ b/docs/stack.md
@@ -19,6 +19,7 @@ Technology choices for BetaApp. For usage patterns, see the relevant README in `
 | **Supabase** | Hosted Postgres with Auth, Realtime, RLS, and web dashboard as admin CMS | Credentials via `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` in `.env` (gitignored) |
 | **tauri-plugin-deep-link** | Handles `betaapp://` URL scheme on Android | Plugin registered; magic link auth wiring planned for Phase 11 |
 | **Leaflet + react-leaflet** | Interactive maps with OSM + Stadia Alidade Satellite tiles | CSS imported in `main.tsx`; custom SVG marker icons; Stadia API key via `VITE_STADIA_API_KEY` |
+| **recharts** | Composable React charting library for stats visualisations | Used in `StatsView`; chart colours are hardcoded hex values (CSS variables are not accessible inside canvas/SVG renderers) |
 | **pnpm** | Fast, strict dependency resolution | Never use `npm` or `yarn` |
 
 ---

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"react-leaflet": "4",
+		"recharts": "^3.8.0",
 		"tailwind-merge": "^3.3.1",
 		"tailwindcss": "^4.1.15",
 		"zod": "^4.3.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       react-leaflet:
         specifier: '4'
         version: 4.2.1(leaflet@1.9.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      recharts:
+        specifier: ^3.8.0
+        version: 3.8.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react-is@17.0.2)(react@18.3.1)(redux@5.0.1)
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.5.0
@@ -73,7 +76,7 @@ importers:
         version: 4.3.6
       zustand:
         specifier: ^5.0.11
-        version: 5.0.11(@types/react@18.3.28)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
+        version: 5.0.11(@types/react@18.3.28)(immer@11.1.4)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
     devDependencies:
       '@biomejs/biome':
         specifier: 2.3.2
@@ -535,6 +538,17 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
 
+  '@reduxjs/toolkit@2.11.2':
+    resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
@@ -678,6 +692,9 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@supabase/auth-js@2.99.0':
     resolution: {integrity: sha512-tHiIST/OEoLmWBE+3X69xRY5srJM/lL86KltmMlIfDo9ePJLo14vQQV9T4NF+P+MoGhCwQL1GTmk51zuAFMXKw==}
@@ -984,6 +1001,33 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -1012,6 +1056,9 @@ packages:
 
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -1125,6 +1172,10 @@ packages:
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -1145,6 +1196,50 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -1157,6 +1252,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
@@ -1200,6 +1298,9 @@ packages:
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
+  es-toolkit@1.45.1:
+    resolution: {integrity: sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==}
+
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
@@ -1211,6 +1312,9 @@ packages:
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
@@ -1276,6 +1380,12 @@ packages:
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
+  immer@10.2.0:
+    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
+
+  immer@11.1.4:
+    resolution: {integrity: sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==}
+
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
@@ -1285,6 +1395,10 @@ packages:
 
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -1535,6 +1649,18 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
 
+  react-redux@9.2.0:
+    resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
@@ -1547,13 +1673,32 @@ packages:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
 
+  recharts@3.8.0:
+    resolution: {integrity: sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
 
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   rollup@4.59.0:
     resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
@@ -1710,6 +1855,9 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   vite@6.4.1:
     resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
@@ -2184,6 +2332,18 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@18.3.28)(react@18.3.1)(redux@5.0.1))(react@18.3.1)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.4
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
+    optionalDependencies:
+      react: 18.3.1
+      react-redux: 9.2.0(@types/react@18.3.28)(react@18.3.1)(redux@5.0.1)
+
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
@@ -2262,6 +2422,8 @@ snapshots:
     optional: true
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@supabase/auth-js@2.99.0':
     dependencies:
@@ -2553,6 +2715,30 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
@@ -2579,6 +2765,8 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@types/ws@8.18.1':
     dependencies:
@@ -2713,6 +2901,8 @@ snapshots:
 
   chownr@1.1.4: {}
 
+  clsx@2.1.1: {}
+
   convert-source-map@2.0.0: {}
 
   cookie-es@2.0.0: {}
@@ -2733,6 +2923,44 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   data-urls@7.0.0:
     dependencies:
       whatwg-mimetype: 5.0.0
@@ -2743,6 +2971,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   decimal.js@10.6.0: {}
 
@@ -2774,6 +3004,8 @@ snapshots:
   entities@6.0.1: {}
 
   es-module-lexer@2.0.0: {}
+
+  es-toolkit@1.45.1: {}
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -2809,6 +3041,8 @@ snapshots:
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
+
+  eventemitter3@5.0.4: {}
 
   expand-template@2.0.3: {}
 
@@ -2859,11 +3093,17 @@ snapshots:
 
   ieee754@1.2.1: {}
 
+  immer@10.2.0: {}
+
+  immer@11.1.4: {}
+
   indent-string@4.0.0: {}
 
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
+
+  internmap@2.0.3: {}
 
   is-potential-custom-element-name@1.0.1: {}
 
@@ -3094,6 +3334,15 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  react-redux@9.2.0(@types/react@18.3.28)(react@18.3.1)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 18.3.1
+      use-sync-external-store: 1.6.0(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      redux: 5.0.1
+
   react-refresh@0.17.0: {}
 
   react@18.3.1:
@@ -3106,12 +3355,40 @@ snapshots:
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
+  recharts@3.8.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react-is@17.0.2)(react@18.3.1)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@18.3.28)(react@18.3.1)(redux@5.0.1))(react@18.3.1)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.45.1
+      eventemitter3: 5.0.4
+      immer: 10.2.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-is: 17.0.2
+      react-redux: 9.2.0(@types/react@18.3.28)(react@18.3.1)(redux@5.0.1)
+      reselect: 5.1.1
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@18.3.1)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
   redent@3.0.0:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
+
   require-from-string@2.0.2: {}
+
+  reselect@5.1.1: {}
 
   rollup@4.59.0:
     dependencies:
@@ -3270,6 +3547,23 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
+
   vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.31.1):
     dependencies:
       esbuild: 0.25.12
@@ -3345,8 +3639,9 @@ snapshots:
 
   zod@4.3.6: {}
 
-  zustand@5.0.11(@types/react@18.3.28)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1)):
+  zustand@5.0.11(@types/react@18.3.28)(immer@11.1.4)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1)):
     optionalDependencies:
       '@types/react': 18.3.28
+      immer: 11.1.4
       react: 18.3.1
       use-sync-external-store: 1.6.0(react@18.3.1)

--- a/src/components/organisms/Drawer.tsx
+++ b/src/components/organisms/Drawer.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from "@tanstack/react-router";
 import {
+	BarChart2,
 	CircleUser,
 	Map as MapIcon,
 	MapPin,
@@ -87,6 +88,15 @@ export const Drawer = ({ isOpen, onClose }: DrawerProps) => {
 							<span>Add Location</span>
 						</button>
 					)}
+
+					<button
+						type="button"
+						className="flex items-center gap-3 py-3 px-2 text-left rounded-lg hover:bg-surface-hover"
+						onClick={() => handleNav("/stats")}
+					>
+						<BarChart2 size={18} />
+						<span>Stats</span>
+					</button>
 
 					<button
 						type="button"

--- a/src/features/climbs/README.md
+++ b/src/features/climbs/README.md
@@ -95,8 +95,22 @@ CREATE TABLE IF NOT EXISTS climbs (
 | `useUpdateClimbMoves()` | Mutation — `{ id, moves }` — replaces moves JSON string + silent push |
 | `useLinkClimbToRoute()` | Mutation — `{ climbId, routeId }` — upgrade flow in EditClimbView |
 | `useDeleteClimb()` | Mutation — soft delete + silent push |
+| `useClimbStats(discipline)` | Grade distribution, sends per month, and burns per send — all from local SQLite via `climbs.stats.ts` |
 
 After each mutation a **silent push** fires: `pushClimbs(userId)` runs in the background, toasting success or "saved offline" on failure.
+
+---
+
+## climbs.stats.ts
+
+Read-only analytics functions — all query local SQLite, no Supabase calls.
+
+| Function | Returns |
+|---|---|
+| `fetchGradeDistribution(userId, discipline)` | `GradeStatusBucket[]` — per-grade counts segmented into `sent` (sent/redpoint/flash/onsight), `project`, and `todo`, ordered by `grades_cache.sort_order` |
+| `fetchSendsPerMonth(userId, discipline)` | `MonthSendCount[]` — sent count grouped by `YYYY-MM`, ordered chronologically |
+| `fetchBurnsPerSend(userId, discipline)` | `BurnsPerSend[]` — average burn count per send at each grade (sent climbs only), ordered by grade |
+| `fetchClimbStats(userId, discipline)` | Runs all three above in parallel, returns `ClimbStats` |
 
 ---
 

--- a/src/features/climbs/climbs.queries.ts
+++ b/src/features/climbs/climbs.queries.ts
@@ -3,6 +3,7 @@ import { useAuthStore } from "@/features/auth/auth.store";
 import { pushClimbs } from "@/features/sync/sync.service";
 import { useUiStore } from "@/stores/ui.store";
 import type { ClimbFormValues } from "./climbs.schema";
+import { fetchClimbStats, type Discipline } from "./climbs.stats";
 import {
 	fetchClimb,
 	fetchClimbs,
@@ -117,5 +118,14 @@ export function useDeleteClimb() {
 			qc.invalidateQueries({ queryKey: [CLIMBS_KEY] });
 			silentPush(userId);
 		},
+	});
+}
+
+export function useClimbStats(discipline: Discipline) {
+	const userId = useAuthStore((s) => s.user?.id);
+	return useQuery({
+		queryKey: ["climb_stats", userId, discipline],
+		queryFn: () => fetchClimbStats(userId ?? "", discipline),
+		enabled: !!userId,
 	});
 }

--- a/src/features/climbs/climbs.stats.ts
+++ b/src/features/climbs/climbs.stats.ts
@@ -1,0 +1,156 @@
+import { getDb } from "@/lib/db";
+
+export type Discipline = "sport" | "boulder";
+
+// ── Grade distribution (stacked by status group) ──────────────────────────────
+
+export type GradeStatusBucket = {
+	grade: string;
+	sort_order: number;
+	sent: number;
+	project: number;
+	todo: number;
+};
+
+const SENT_STATUSES = "'sent','redpoint','flash','onsight'";
+
+export async function fetchGradeDistribution(
+	userId: string,
+	discipline: Discipline,
+): Promise<GradeStatusBucket[]> {
+	const db = await getDb();
+
+	type Row = {
+		grade: string;
+		sort_order: number;
+		sent_group: string;
+		count: number;
+	};
+
+	const rows = await db.select<Row[]>(
+		`SELECT
+      c.grade,
+      COALESCE(g.sort_order, 9999) AS sort_order,
+      CASE
+        WHEN c.sent_status IN (${SENT_STATUSES}) THEN 'sent'
+        ELSE c.sent_status
+      END AS sent_group,
+      COUNT(*) AS count
+    FROM climbs c
+    LEFT JOIN grades_cache g ON g.discipline = c.route_type AND g.grade = c.grade
+    WHERE c.user_id = ? AND c.deleted_at IS NULL AND c.route_type = ?
+    GROUP BY c.grade, sent_group
+    ORDER BY sort_order ASC, c.grade ASC`,
+		[userId, discipline],
+	);
+
+	// Pivot rows into GradeStatusBucket
+	const map = new Map<string, GradeStatusBucket>();
+	for (const row of rows) {
+		let bucket = map.get(row.grade);
+		if (!bucket) {
+			bucket = { grade: row.grade, sort_order: row.sort_order, sent: 0, project: 0, todo: 0 };
+			map.set(row.grade, bucket);
+		}
+		if (row.sent_group === "sent") bucket.sent += row.count;
+		else if (row.sent_group === "project") bucket.project += row.count;
+		else if (row.sent_group === "todo") bucket.todo += row.count;
+	}
+
+	return [...map.values()].sort((a, b) => a.sort_order - b.sort_order);
+}
+
+// ── Sends per month ───────────────────────────────────────────────────────────
+
+export type MonthSendCount = {
+	month: string; // "YYYY-MM"
+	count: number;
+};
+
+export async function fetchSendsPerMonth(
+	userId: string,
+	discipline: Discipline,
+): Promise<MonthSendCount[]> {
+	const db = await getDb();
+	return db.select<MonthSendCount[]>(
+		`SELECT
+      strftime('%Y-%m', c.created_at) AS month,
+      COUNT(*) AS count
+    FROM climbs c
+    WHERE c.user_id = ?
+      AND c.deleted_at IS NULL
+      AND c.route_type = ?
+      AND c.sent_status IN (${SENT_STATUSES})
+    GROUP BY month
+    ORDER BY month ASC`,
+		[userId, discipline],
+	);
+}
+
+// ── Burns per send at each grade ──────────────────────────────────────────────
+
+export type BurnsPerSend = {
+	grade: string;
+	sort_order: number;
+	burns_per_send: number;
+};
+
+export async function fetchBurnsPerSend(
+	userId: string,
+	discipline: Discipline,
+): Promise<BurnsPerSend[]> {
+	const db = await getDb();
+
+	type Row = {
+		grade: string;
+		sort_order: number;
+		burn_count: number;
+		send_count: number;
+	};
+
+	const rows = await db.select<Row[]>(
+		`SELECT
+      c.grade,
+      COALESCE(g.sort_order, 9999) AS sort_order,
+      COUNT(b.id) AS burn_count,
+      COUNT(DISTINCT c.id) AS send_count
+    FROM climbs c
+    LEFT JOIN burns b ON b.climb_id = c.id AND b.deleted_at IS NULL
+    LEFT JOIN grades_cache g ON g.discipline = c.route_type AND g.grade = c.grade
+    WHERE c.user_id = ?
+      AND c.deleted_at IS NULL
+      AND c.route_type = ?
+      AND c.sent_status IN (${SENT_STATUSES})
+    GROUP BY c.grade
+    ORDER BY sort_order ASC`,
+		[userId, discipline],
+	);
+
+	return rows
+		.filter((r) => r.send_count > 0)
+		.map((r) => ({
+			grade: r.grade,
+			sort_order: r.sort_order,
+			burns_per_send: Math.round((r.burn_count / r.send_count) * 10) / 10,
+		}));
+}
+
+// ── Combined stats (single query trip) ───────────────────────────────────────
+
+export type ClimbStats = {
+	gradeDistribution: GradeStatusBucket[];
+	sendsPerMonth: MonthSendCount[];
+	burnsPerSend: BurnsPerSend[];
+};
+
+export async function fetchClimbStats(
+	userId: string,
+	discipline: Discipline,
+): Promise<ClimbStats> {
+	const [gradeDistribution, sendsPerMonth, burnsPerSend] = await Promise.all([
+		fetchGradeDistribution(userId, discipline),
+		fetchSendsPerMonth(userId, discipline),
+		fetchBurnsPerSend(userId, discipline),
+	]);
+	return { gradeDistribution, sendsPerMonth, burnsPerSend };
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -19,6 +19,7 @@ import ClimbDetailView from "@/views/ClimbDetailView";
 import CragView from "@/views/CragView";
 import EditClimbView from "@/views/EditClimbView";
 import HomeView from "@/views/HomeView";
+import StatsView from "@/views/StatsView";
 import MapView from "@/views/MapView";
 import ProfileView from "@/views/ProfileView";
 import RegionView from "@/views/RegionView";
@@ -194,6 +195,13 @@ const addLocationRoute = createRoute({
 	component: AddLocationView,
 });
 
+const statsRoute = createRoute({
+	getParentRoute: () => rootRoute,
+	path: "/stats",
+	beforeLoad: requireAuth,
+	component: StatsView,
+});
+
 const adminLocationsRoute = createRoute({
 	getParentRoute: () => rootRoute,
 	path: "/admin/locations",
@@ -227,6 +235,7 @@ const routeTree = rootRoute.addChildren([
 	wallRoute,
 	routeDetailRoute,
 	addLocationRoute,
+	statsRoute,
 	adminLocationsRoute,
 	adminVerificationRoute,
 ]);

--- a/src/views/README.md
+++ b/src/views/README.md
@@ -28,6 +28,7 @@ Router defined in `src/router.tsx` using `createMemoryHistory` (required for And
 | `/locations/add` | `AddLocationView` | required | Add a sub-area/crag/wall using location drill-down; admin creates verified, user creates pending |
 | `/routes/add` | `AddEditRouteView` | required | Add a new route with location drill-down; admin creates verified, user creates pending |
 | `/routes/$routeId/edit` | `AddEditRouteView` | required | Edit an existing route including changing its wall |
+| `/stats` | `StatsView` | required | Personal climbing stats — grade distribution, sends per month, burns per send |
 | `/admin/locations` | `admin/LocationManagerView` | admin | Add/delete countries and regions in Supabase |
 | `/admin/verify` | `admin/VerificationView` | admin | Unified pending-submissions queue: routes and locations grouped by type with count badges; inline approve, edit, merge, reject |
 
@@ -98,6 +99,14 @@ Legacy route submission view. Reads `wallId` and `wallName` from search params. 
 
 ### AddEditRouteView `/routes/add` and `/routes/$routeId/edit`
 Unified add/edit route form with cascading location picker (`LocationDrillDown` molecule). Resolves the full location chain (wall → crag → sub_region → region → country) for edit mode pre-population. Admin creates routes as `verified`; users create as `pending`. Calls `useAddRoute()` or `useEditRoute()`. On success navigates back.
+
+### StatsView `/stats`
+Personal climbing analytics. Sport/Boulder discipline toggle at top. Three recharts `BarChart` panels:
+- **Grade distribution** — stacked bar per grade (sent/project/todo); grades ordered by `grades_cache.sort_order`
+- **Sends per month** — single bar per month showing sends (sent/redpoint/flash/onsight)
+- **Burns per send** — average attempts per send at each grade (sent climbs only; requires burns data)
+
+Each panel shows a "Not enough data yet" empty state when the data array is empty. Powered by `useClimbStats(discipline)` → `climbs.stats.ts`.
 
 ### admin/LocationManagerView `/admin/locations`
 Admin only. Loads countries + regions. Inline forms to add/delete entries. Calls admin mutation functions from `locations.service`.

--- a/src/views/StatsView.tsx
+++ b/src/views/StatsView.tsx
@@ -1,0 +1,242 @@
+import { useState } from "react";
+import {
+	Bar,
+	BarChart,
+	CartesianGrid,
+	Legend,
+	ResponsiveContainer,
+	Tooltip,
+	XAxis,
+	YAxis,
+} from "recharts";
+import { Spinner } from "@/components/atoms/Spinner";
+import { ToggleGroup } from "@/components/atoms/ToggleGroup";
+import { useClimbStats } from "@/features/climbs/climbs.queries";
+import type { Discipline } from "@/features/climbs/climbs.stats";
+
+// ── Chart colours (hardcoded — recharts doesn't read CSS vars) ────────────────
+
+const COLOR_SENT = "#059669";
+const COLOR_PROJECT = "#d97706";
+const COLOR_TODO = "#8a7e72";
+const AXIS_COLOR = "#b5a99b";
+const GRID_COLOR = "#4a3f34";
+const TOOLTIP_BG = "#2a2420";
+const TOOLTIP_BORDER = "#4a3f34";
+
+// ── Shared tooltip style ──────────────────────────────────────────────────────
+
+const tooltipStyle = {
+	backgroundColor: TOOLTIP_BG,
+	border: `1px solid ${TOOLTIP_BORDER}`,
+	borderRadius: "0.5rem",
+	color: "#f5f0eb",
+	fontSize: "0.75rem",
+};
+
+// ── Chart section wrapper ─────────────────────────────────────────────────────
+
+const ChartCard = ({
+	title,
+	children,
+	empty,
+}: {
+	title: string;
+	children: React.ReactNode;
+	empty?: boolean;
+}) => (
+	<div className="rounded-lg bg-surface-card p-4 flex flex-col gap-3">
+		<p className="text-sm font-semibold text-text-secondary uppercase tracking-wide">
+			{title}
+		</p>
+		{empty ? (
+			<p className="text-text-tertiary text-sm text-center py-4">
+				Not enough data yet.
+			</p>
+		) : (
+			children
+		)}
+	</div>
+);
+
+// ── Grade distribution chart ──────────────────────────────────────────────────
+
+const GradeDistributionChart = ({
+	data,
+}: {
+	data: { grade: string; sent: number; project: number; todo: number }[];
+}) => (
+	<ResponsiveContainer width="100%" height={200}>
+		<BarChart data={data} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
+			<CartesianGrid strokeDasharray="3 3" stroke={GRID_COLOR} vertical={false} />
+			<XAxis
+				dataKey="grade"
+				tick={{ fill: AXIS_COLOR, fontSize: 10 }}
+				axisLine={false}
+				tickLine={false}
+				interval={0}
+				angle={-35}
+				textAnchor="end"
+				height={40}
+			/>
+			<YAxis
+				tick={{ fill: AXIS_COLOR, fontSize: 10 }}
+				axisLine={false}
+				tickLine={false}
+				allowDecimals={false}
+			/>
+			<Tooltip
+				contentStyle={tooltipStyle}
+				cursor={{ fill: "rgba(255,255,255,0.04)" }}
+			/>
+			<Legend
+				wrapperStyle={{ fontSize: "0.7rem", color: AXIS_COLOR, paddingTop: "4px" }}
+			/>
+			<Bar dataKey="sent" stackId="a" fill={COLOR_SENT} name="Sent" radius={[0, 0, 0, 0]} />
+			<Bar dataKey="project" stackId="a" fill={COLOR_PROJECT} name="Project" radius={[0, 0, 0, 0]} />
+			<Bar dataKey="todo" stackId="a" fill={COLOR_TODO} name="Todo" radius={[3, 3, 0, 0]} />
+		</BarChart>
+	</ResponsiveContainer>
+);
+
+// ── Sends per month chart ─────────────────────────────────────────────────────
+
+const MonthLabel = ({ month }: { month: string }) => {
+	const [y, m] = month.split("-");
+	return `${m}/${y.slice(2)}`;
+};
+
+const SendsPerMonthChart = ({
+	data,
+}: {
+	data: { month: string; count: number }[];
+}) => {
+	const displayData = data.map((d) => ({
+		...d,
+		label: MonthLabel({ month: d.month }),
+	}));
+
+	return (
+		<ResponsiveContainer width="100%" height={180}>
+			<BarChart
+				data={displayData}
+				margin={{ top: 4, right: 4, left: -20, bottom: 0 }}
+			>
+				<CartesianGrid strokeDasharray="3 3" stroke={GRID_COLOR} vertical={false} />
+				<XAxis
+					dataKey="label"
+					tick={{ fill: AXIS_COLOR, fontSize: 10 }}
+					axisLine={false}
+					tickLine={false}
+				/>
+				<YAxis
+					tick={{ fill: AXIS_COLOR, fontSize: 10 }}
+					axisLine={false}
+					tickLine={false}
+					allowDecimals={false}
+				/>
+				<Tooltip
+					contentStyle={tooltipStyle}
+					cursor={{ fill: "rgba(255,255,255,0.04)" }}
+					formatter={(v: number) => [v, "Sends"]}
+				/>
+				<Bar dataKey="count" fill={COLOR_SENT} name="Sends" radius={[3, 3, 0, 0]} />
+			</BarChart>
+		</ResponsiveContainer>
+	);
+};
+
+// ── Burns per send chart ──────────────────────────────────────────────────────
+
+const BurnsPerSendChart = ({
+	data,
+}: {
+	data: { grade: string; burns_per_send: number }[];
+}) => (
+	<ResponsiveContainer width="100%" height={180}>
+		<BarChart data={data} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
+			<CartesianGrid strokeDasharray="3 3" stroke={GRID_COLOR} vertical={false} />
+			<XAxis
+				dataKey="grade"
+				tick={{ fill: AXIS_COLOR, fontSize: 10 }}
+				axisLine={false}
+				tickLine={false}
+				interval={0}
+				angle={-35}
+				textAnchor="end"
+				height={40}
+			/>
+			<YAxis
+				tick={{ fill: AXIS_COLOR, fontSize: 10 }}
+				axisLine={false}
+				tickLine={false}
+			/>
+			<Tooltip
+				contentStyle={tooltipStyle}
+				cursor={{ fill: "rgba(255,255,255,0.04)" }}
+				formatter={(v: number) => [v, "Burns/send"]}
+			/>
+			<Bar
+				dataKey="burns_per_send"
+				fill={COLOR_PROJECT}
+				name="Burns/send"
+				radius={[3, 3, 0, 0]}
+			/>
+		</BarChart>
+	</ResponsiveContainer>
+);
+
+// ── View ──────────────────────────────────────────────────────────────────────
+
+const StatsView = () => {
+	const [discipline, setDiscipline] = useState<Discipline>("sport");
+	const { data: stats, isLoading } = useClimbStats(discipline);
+
+	return (
+		<div className="flex flex-col gap-4">
+			<h1 className="text-lg font-display font-semibold">Stats</h1>
+
+			<ToggleGroup
+				options={[
+					{ value: "sport", label: "Sport" },
+					{ value: "boulder", label: "Boulder" },
+				]}
+				value={discipline}
+				onChange={(v) => setDiscipline(v as Discipline)}
+			/>
+
+			{isLoading && (
+				<div className="flex justify-center pt-8">
+					<Spinner />
+				</div>
+			)}
+
+			{!isLoading && stats && (
+				<>
+					<ChartCard
+						title="Grade distribution"
+						empty={stats.gradeDistribution.length === 0}
+					>
+						<GradeDistributionChart data={stats.gradeDistribution} />
+					</ChartCard>
+
+					<ChartCard
+						title="Sends per month"
+						empty={stats.sendsPerMonth.length === 0}
+					>
+						<SendsPerMonthChart data={stats.sendsPerMonth} />
+					</ChartCard>
+
+					<ChartCard
+						title="Burns per send"
+						empty={stats.burnsPerSend.length === 0}
+					>
+						<BurnsPerSendChart data={stats.burnsPerSend} />
+					</ChartCard>
+				</>
+			)}
+		</div>
+	);
+};
+
+export default StatsView;


### PR DESCRIPTION
…, closes #62

Adds a /stats view accessible from the drawer menu showing three recharts BarChart panels per discipline (sport / boulder toggle):
- Grade distribution stacked by sent / project / todo
- Sends per month
- Burns per send at each grade

Data comes from three new SQLite queries in climbs.stats.ts (fetchGradeDistribution, fetchSendsPerMonth, fetchBurnsPerSend) joined with grades_cache for correct sort order. All three run in parallel via fetchClimbStats, exposed through the new useClimbStats hook. Adds recharts ^3.8.0 as a dependency.

https://claude.ai/code/session_014rTAE9dgsmoSqaykH9LXnB