### PR TITLE
feat: add body dimensions vs grade bubble chart to route detail view, closes #63

### DIFF
--- a/src/components/README.md
+++ b/src/components/README.md
@@ -46,6 +46,7 @@ templates   Layout shells with no real data — just children/slots.
 | `ImportBetaSheet` | Bottom sheet for importing a move list from plain text (one-per-line) or CSV. Auto-detects CSV when >1 line ends with a comma. Replaces existing moves on import. Props: `climbId`, `isOpen`, `onClose`. |
 | `ConfirmDialog` | Centred modal overlay for confirming destructive or navigating-away actions. Props: `isOpen`, `title`, `message`, `confirmLabel?`, `cancelLabel?`, `onConfirm`, `onCancel`. |
 | `RoutePickerSheet` | Full-screen sheet that chains `LocationDrillDown` with a route list (verified routes only for the selected wall). Used in `AddClimbView` to link a log entry to a community route. Props: `isOpen`, `onClose`, `onSelect(route)`. |
+| `RouteBodyChart` | Bubble chart (recharts `ScatterChart`) showing how climbers' body dimensions (height or ape index) correlate with grade on a specific route. Only sent climbs are included. Toggles X-axis between height and ape index. Renders an empty state when fewer than 5 climbers have data. Data comes from the `get_route_body_stats` Supabase RPC. Props: `routeId`, `routeType`. |
 
 ### Organisms
 | Component | Purpose |

--- a/src/components/molecules/RouteBodyChart.tsx
+++ b/src/components/molecules/RouteBodyChart.tsx
@@ -1,0 +1,149 @@
+import { useState } from "react";
+import {
+	CartesianGrid,
+	ResponsiveContainer,
+	Scatter,
+	ScatterChart,
+	Tooltip,
+	XAxis,
+	YAxis,
+	ZAxis,
+} from "recharts";
+import { ToggleGroup } from "@/components/atoms/ToggleGroup";
+import { useGrades } from "@/features/grades/grades.queries";
+import { useRouteBodyStats } from "@/features/routes/routes.queries";
+
+// ── Chart colours (hardcoded — recharts doesn't read CSS vars) ────────────────
+
+const COLOR_SENT = "#059669";
+const AXIS_COLOR = "#b5a99b";
+const GRID_COLOR = "#4a3f34";
+const TOOLTIP_BG = "#2a2420";
+const TOOLTIP_BORDER = "#4a3f34";
+
+// Minimum number of climbers (sum of counts) required to show the chart
+const MIN_CLIMBERS = 5;
+
+type XMetric = "height" | "ape_index";
+
+interface Props {
+	routeId: string;
+	routeType: "sport" | "boulder";
+}
+
+export const RouteBodyChart = ({ routeId, routeType }: Props) => {
+	const [xMetric, setXMetric] = useState<XMetric>("height");
+	const { data: stats = [], isLoading } = useRouteBodyStats(routeId);
+	const { data: grades = [] } = useGrades(routeType);
+
+	const gradeOrder = new Map(grades.map((g) => [g.grade, g.sort_order]));
+	const gradeByOrder = new Map(grades.map((g) => [g.sort_order, g.grade]));
+
+	const filtered = stats.filter((s) =>
+		xMetric === "height" ? s.height_cm != null : s.ape_index_cm != null,
+	);
+	const totalClimbers = filtered.reduce((sum, s) => sum + s.count, 0);
+
+	const title = (
+		<p className="text-sm font-semibold text-text-secondary uppercase tracking-wide">
+			Body dimensions vs grade
+		</p>
+	);
+
+	if (isLoading) return null;
+
+	if (totalClimbers < MIN_CLIMBERS) {
+		return (
+			<div className="rounded-[var(--radius-lg)] bg-surface-card border border-card-border shadow-card p-4 flex flex-col gap-3">
+				{title}
+				<p className="text-text-tertiary text-sm text-center py-4">
+					Not enough data yet.
+				</p>
+			</div>
+		);
+	}
+
+	const chartData = filtered.map((s) => ({
+		x: xMetric === "height" ? s.height_cm : (s.ape_index_cm ?? 0),
+		y: gradeOrder.get(s.grade) ?? 0,
+		z: s.count,
+		grade: s.grade,
+		count: s.count,
+	}));
+
+	const uniqueGrades = [...new Set(filtered.map((s) => s.grade))].sort(
+		(a, b) => (gradeOrder.get(a) ?? 0) - (gradeOrder.get(b) ?? 0),
+	);
+	const yTicks = uniqueGrades.map((g) => gradeOrder.get(g) ?? 0);
+	const yMin = Math.min(...yTicks) - 1;
+	const yMax = Math.max(...yTicks) + 1;
+
+	return (
+		<div className="rounded-[var(--radius-lg)] bg-surface-card border border-card-border shadow-card p-4 flex flex-col gap-3">
+			{title}
+			<ToggleGroup
+				options={[
+					{ value: "height", label: "Height" },
+					{ value: "ape_index", label: "Ape index" },
+				]}
+				value={xMetric}
+				onChange={(v) => setXMetric(v as XMetric)}
+			/>
+			<ResponsiveContainer width="100%" height={220}>
+				<ScatterChart margin={{ top: 8, right: 16, left: -16, bottom: 0 }}>
+					<CartesianGrid strokeDasharray="3 3" stroke={GRID_COLOR} />
+					<XAxis
+						type="number"
+						dataKey="x"
+						name={xMetric === "height" ? "Height" : "Ape index"}
+						unit="cm"
+						tick={{ fill: AXIS_COLOR, fontSize: 10 }}
+						axisLine={false}
+						tickLine={false}
+					/>
+					<YAxis
+						type="number"
+						dataKey="y"
+						name="Grade"
+						domain={[yMin, yMax]}
+						ticks={yTicks}
+						tickFormatter={(v: number) => gradeByOrder.get(v) ?? String(v)}
+						tick={{ fill: AXIS_COLOR, fontSize: 10 }}
+						axisLine={false}
+						tickLine={false}
+					/>
+					<ZAxis type="number" dataKey="z" range={[40, 400]} name="Climbers" />
+					<Tooltip
+						cursor={{ strokeDasharray: "3 3" }}
+						content={({ payload }) => {
+							if (!payload?.length) return null;
+							const d = payload[0]?.payload as (typeof chartData)[0];
+							if (!d) return null;
+							return (
+								<div
+									style={{
+										backgroundColor: TOOLTIP_BG,
+										border: `1px solid ${TOOLTIP_BORDER}`,
+										borderRadius: "0.5rem",
+										color: "#f5f0eb",
+										fontSize: "0.75rem",
+										padding: "8px 12px",
+									}}
+								>
+									<p style={{ fontWeight: 600 }}>{d.grade}</p>
+									<p>
+										{xMetric === "height" ? "Height" : "Ape index"}: {d.x}cm
+									</p>
+									<p>
+										{d.count} climber{d.count !== 1 ? "s" : ""}
+									</p>
+								</div>
+							);
+						}}
+					/>
+					<Scatter data={chartData} fill={COLOR_SENT} fillOpacity={0.75} />
+				</ScatterChart>
+			</ResponsiveContainer>
+		</div>
+	);
+};

--- a/src/features/routes/README.md
+++ b/src/features/routes/README.md
@@ -52,6 +52,14 @@ RouteLinkSubmitSchema = {
   url: string          // must start with http:// or https://
   title?: string
 }
+
+// Returned by the get_route_body_stats Supabase RPC (not stored locally)
+RouteBodyStat = {
+  height_cm: number
+  ape_index_cm: number | null
+  grade: string
+  count: number           // number of climbers at this height/ape + grade combination
+}
 ```
 
 ---
@@ -89,6 +97,12 @@ Only populated when the user downloads a region (see [`locations/README.md`](../
 | `searchLocalRoutes(query)` | LIKE search on local `routes_cache` by name or grade (verified only, limit 30) |
 | `updateRouteDescription(id, description)` | Updates description in Supabase + local cache |
 
+### Route body stats
+
+| Function | What it does |
+|---|---|
+| `fetchRouteBodyStats(routeId)` | Calls `get_route_body_stats` Supabase RPC; returns aggregated height/ape index vs grade data for all climbers who have sent the route (SECURITY DEFINER — bypasses RLS to include all users) |
+
 ### Route links
 
 | Function | What it does |
@@ -125,6 +139,7 @@ useVerifyRoute()           // admin mutation
 useRejectRoute()           // admin mutation
 useUpdateRouteFields()     // admin mutation
 useMergeRoute()            // admin mutation
+useRouteBodyStats(routeId) // body dimension vs grade scatter data from Supabase RPC
 useRouteLinks(routeId)     // non-deleted links for a route from local cache
 useAddRouteLink(routeId)   // mutation — { url, title?, userId }
 useDeleteRouteLink(routeId) // mutation — id

--- a/src/features/routes/routes.queries.ts
+++ b/src/features/routes/routes.queries.ts
@@ -9,6 +9,7 @@ import {
 	editRoute,
 	fetchAllRoutes,
 	fetchRoute,
+	fetchRouteBodyStats,
 	fetchRouteLinks,
 	fetchRoutes,
 	fetchUnverifiedRoutes,
@@ -200,6 +201,16 @@ export function useMergeRoute() {
 			qc.invalidateQueries({ queryKey: ["unverified_routes"] });
 			qc.invalidateQueries({ queryKey: ["all_routes"] });
 		},
+	});
+}
+
+// ── Route body stats ──────────────────────────────────────────────────────────
+
+export function useRouteBodyStats(routeId: string) {
+	return useQuery({
+		queryKey: ["route_body_stats", routeId],
+		queryFn: () => fetchRouteBodyStats(routeId),
+		enabled: !!routeId,
 	});
 }
 

--- a/src/features/routes/routes.schema.ts
+++ b/src/features/routes/routes.schema.ts
@@ -47,3 +47,11 @@ export const RouteLinkSubmitSchema = z.object({
 
 export type RouteLink = z.infer<typeof RouteLinkSchema>;
 export type RouteLinkSubmitValues = z.infer<typeof RouteLinkSubmitSchema>;
+
+// Returned by the get_route_body_stats Supabase RPC
+export type RouteBodyStat = {
+	height_cm: number;
+	ape_index_cm: number | null;
+	grade: string;
+	count: number;
+};

--- a/src/features/routes/routes.service.ts
+++ b/src/features/routes/routes.service.ts
@@ -1,6 +1,11 @@
 import { getDb } from "@/lib/db";
 import { supabase } from "@/lib/supabase";
-import type { Route, RouteLink, RouteSubmitValues } from "./routes.schema";
+import type {
+	Route,
+	RouteBodyStat,
+	RouteLink,
+	RouteSubmitValues,
+} from "./routes.schema";
 
 export async function fetchRoutes(wallId: string): Promise<Route[]> {
 	const db = await getDb();
@@ -317,6 +322,31 @@ export async function searchVerifiedRoutes(
 		.limit(10);
 	if (error) throw error;
 	return (data ?? []) as VerifiedRouteResult[];
+}
+
+// ── Route body stats ──────────────────────────────────────────────────────────
+
+// Requires Supabase RPC:
+//
+// CREATE OR REPLACE FUNCTION public.get_route_body_stats(p_route_id uuid)
+// RETURNS TABLE (height_cm integer, ape_index_cm integer, grade text, count bigint)
+// LANGUAGE sql SECURITY DEFINER STABLE AS $$
+//   SELECT u.height_cm, u.ape_index_cm, c.grade, COUNT(*) AS count
+//   FROM climbs c JOIN users u ON u.id = c.user_id
+//   WHERE c.route_id = p_route_id
+//     AND c.sent_status IN ('sent', 'redpoint', 'flash', 'onsight')
+//     AND c.deleted_at IS NULL AND u.height_cm IS NOT NULL
+//   GROUP BY u.height_cm, u.ape_index_cm, c.grade;
+// $$;
+
+export async function fetchRouteBodyStats(
+	routeId: string,
+): Promise<RouteBodyStat[]> {
+	const { data, error } = await supabase.rpc("get_route_body_stats", {
+		p_route_id: routeId,
+	});
+	if (error) throw error;
+	return (data ?? []) as RouteBodyStat[];
 }
 
 // ── Route links ───────────────────────────────────────────────────────────────

--- a/src/views/RouteDetailView.tsx
+++ b/src/views/RouteDetailView.tsx
@@ -7,6 +7,7 @@ import { Input } from "@/components/atoms/Input";
 import { Spinner } from "@/components/atoms/Spinner";
 import { AdminImageGallery } from "@/components/molecules/AdminImageGallery";
 import { EditableDescription } from "@/components/molecules/EditableDescription";
+import { RouteBodyChart } from "@/components/molecules/RouteBodyChart";
 import { useAuthStore } from "@/features/auth/auth.store";
 import { useClimbs } from "@/features/climbs/climbs.queries";
 import {
@@ -196,7 +197,9 @@ const RouteDetailView = () => {
 				)}
 			</div>
 
-			{existingClimb ? (
+			<RouteBodyChart routeId={routeId} routeType={route.route_type} />
+
+		{existingClimb ? (
 				<Button
 					type="button"
 					variant="primary"


### PR DESCRIPTION
Adds a ScatterChart (recharts) to RouteDetailView showing how climbers'
height and ape index correlate with sent grades on a specific route.
Toggle between height and ape index on the X-axis; bubble size = climber
count. Requires the `get_route_body_stats` Supabase SECURITY DEFINER RPC
to aggregate cross-user climb data. Shows an empty state when fewer than
5 climbers have data.

https://claude.ai/code/session_015GEWAqcKCn5JcV15AhwZFc