### PR TITLE
feat: add climbing route topos — create and view (#topo)

### DIFF
--- a/src/components/README.md
+++ b/src/components/README.md
@@ -47,6 +47,8 @@ templates   Layout shells with no real data — just children/slots.
 | `ConfirmDialog` | Centred modal overlay for confirming destructive or navigating-away actions. Props: `isOpen`, `title`, `message`, `confirmLabel?`, `cancelLabel?`, `onConfirm`, `onCancel`. |
 | `RoutePickerSheet` | Full-screen sheet that chains `LocationDrillDown` with a route list (verified routes only for the selected wall). Used in `AddClimbView` to link a log entry to a community route. Props: `isOpen`, `onClose`, `onSelect(route)`. |
 | `RouteBodyChart` | Bubble chart (recharts `ScatterChart`) showing how climbers' body dimensions (height or ape index) correlate with grade on a specific route. Only sent climbs are included. Toggles X-axis between height and ape index. Renders an empty state when fewer than 5 climbers have data. Data comes from the `get_route_body_stats` Supabase RPC. Props: `routeId`, `routeType`. |
+| `TopoViewer` | SVG route-line overlay on a topo photo. Exports `WallTopoViewer` (multiple colour-coded lines, selectable bottom panel) and `RouteTopoViewer` (single line, no panel). Lines use `vector-effect="non-scaling-stroke"` and transparent fat hit targets for tap detection. Props for wall: `topo`, `lines[]`, `routes[]`, optional `singleRouteId`. Props for route: `topo`. |
+| `TopoModal` | Full-screen topo viewer with pinch-to-zoom (scale 1–4×) and double-tap-to-reset. Wraps `WallTopoViewer` or `RouteTopoViewer` depending on `mode` (`"wall"` \| `"wall-single"` \| `"route"`). Close button in top-left respects safe-area inset. |
 
 ### Organisms
 | Component | Purpose |
@@ -54,6 +56,7 @@ templates   Layout shells with no real data — just children/slots.
 | `ClimbForm` | Full add/edit form — used by both `AddClimbView` and `EditClimbView`. Move list is drag-to-reorder via `@dnd-kit/sortable`; long-press the `GripVertical` handle to activate drag (250ms `TouchSensor` delay). Accepts optional `climbId` prop: when provided, moves auto-save after a 1-second debounce via `useUpdateClimbMoves`, shows a Saving/Saved indicator, and blocks navigation while unsaved changes are in-flight using `useBlocker`. Accepts optional `linkedRoute`, `onOpenRoutePicker`, `onUnlinkRoute` props for displaying/clearing a linked community route (shown above the Save button). |
 | `NavBar` | Bottom navigation bar: Home, Add, Search, Menu |
 | `Drawer` | Slide-up modal sheet |
+| `TopoBuilder` | Admin-only SVG drawing canvas for creating topo route lines. Exports `WallTopoBuilder` (image upload + per-route line drawing with route selector) and `RouteTopoBuilder` (image upload + single line). Point editing: tap to add, drag point handles to reposition, drag midpoint handles to insert new points between existing ones. Props for wall: `wallId`, `routes[]`, `topo`, `lines[]`. Props for route: `routeId`, `topo`. |
 
 ### Templates
 | Component | Purpose |

--- a/src/components/molecules/TopoModal.tsx
+++ b/src/components/molecules/TopoModal.tsx
@@ -1,0 +1,162 @@
+import { useEffect, useRef, useState } from "react";
+import { X } from "lucide-react";
+import type { RouteTopo, WallTopo, WallTopoLine } from "@/features/topos/topos.schema";
+import { RouteTopoViewer, WallTopoViewer } from "./TopoViewer";
+
+interface RouteInfo {
+	id: string;
+	name: string;
+	grade: string;
+}
+
+interface BaseProps {
+	onClose: () => void;
+}
+
+interface WallTopoModalProps extends BaseProps {
+	mode: "wall";
+	topo: WallTopo;
+	lines: WallTopoLine[];
+	routes: RouteInfo[];
+}
+
+interface WallSingleTopoModalProps extends BaseProps {
+	mode: "wall-single";
+	topo: WallTopo;
+	lines: WallTopoLine[];
+	routes: RouteInfo[];
+	routeId: string;
+}
+
+interface RouteTopoModalProps extends BaseProps {
+	mode: "route";
+	topo: RouteTopo;
+}
+
+type TopoModalProps =
+	| WallTopoModalProps
+	| WallSingleTopoModalProps
+	| RouteTopoModalProps;
+
+export const TopoModal = (props: TopoModalProps) => {
+	const { onClose } = props;
+
+	// Pinch-to-zoom state
+	const [scale, setScale] = useState(1);
+	const [origin, setOrigin] = useState({ x: 0, y: 0 });
+	const lastDistance = useRef<number | null>(null);
+	const lastTap = useRef<number>(0);
+	const containerRef = useRef<HTMLDivElement>(null);
+
+	// Close on Android back (Escape key)
+	useEffect(() => {
+		const handler = (e: KeyboardEvent) => {
+			if (e.key === "Escape") onClose();
+		};
+		window.addEventListener("keydown", handler);
+		return () => window.removeEventListener("keydown", handler);
+	}, [onClose]);
+
+	const handleTouchStart = (e: React.TouchEvent) => {
+		if (e.touches.length === 2) {
+			const dx = e.touches[0].clientX - e.touches[1].clientX;
+			const dy = e.touches[0].clientY - e.touches[1].clientY;
+			lastDistance.current = Math.hypot(dx, dy);
+		}
+	};
+
+	const handleTouchMove = (e: React.TouchEvent) => {
+		if (e.touches.length === 2 && lastDistance.current !== null) {
+			const dx = e.touches[0].clientX - e.touches[1].clientX;
+			const dy = e.touches[0].clientY - e.touches[1].clientY;
+			const dist = Math.hypot(dx, dy);
+			const delta = dist / lastDistance.current;
+			lastDistance.current = dist;
+
+			// Pinch center as transform origin
+			const rect = containerRef.current?.getBoundingClientRect();
+			if (rect) {
+				const cx =
+					((e.touches[0].clientX + e.touches[1].clientX) / 2 - rect.left) /
+					rect.width;
+				const cy =
+					((e.touches[0].clientY + e.touches[1].clientY) / 2 - rect.top) /
+					rect.height;
+				setOrigin({ x: cx * 100, y: cy * 100 });
+			}
+
+			setScale((s) => Math.min(4, Math.max(1, s * delta)));
+		}
+	};
+
+	const handleTouchEnd = (e: React.TouchEvent) => {
+		if (e.touches.length < 2) {
+			lastDistance.current = null;
+		}
+		// Double-tap to reset zoom
+		if (e.changedTouches.length === 1) {
+			const now = Date.now();
+			if (now - lastTap.current < 300) {
+				setScale(1);
+				setOrigin({ x: 50, y: 50 });
+			}
+			lastTap.current = now;
+		}
+	};
+
+	return (
+		<div className="fixed inset-0 z-50 bg-black flex flex-col">
+			{/* Header */}
+			<div
+				className="shrink-0 flex items-center px-4 py-3"
+				style={{ paddingTop: "calc(env(safe-area-inset-top) + 0.75rem)" }}
+			>
+				<button
+					type="button"
+					onClick={onClose}
+					className="flex items-center justify-center w-8 h-8 rounded-full bg-white/10 text-white"
+					aria-label="Close"
+				>
+					<X size={18} />
+				</button>
+			</div>
+
+			{/* Zoomable content */}
+			<div
+				ref={containerRef}
+				className="flex-1 overflow-hidden relative"
+				onTouchStart={handleTouchStart}
+				onTouchMove={handleTouchMove}
+				onTouchEnd={handleTouchEnd}
+				style={{ touchAction: "none" }}
+			>
+				<div
+					className="w-full h-full"
+					style={{
+						transform: `scale(${scale})`,
+						transformOrigin: `${origin.x}% ${origin.y}%`,
+						transition:
+							lastDistance.current === null ? "transform 0.15s ease-out" : "none",
+					}}
+				>
+					{props.mode === "wall" && (
+						<WallTopoViewer
+							topo={props.topo}
+							lines={props.lines}
+							routes={props.routes}
+						/>
+					)}
+					{props.mode === "wall-single" && (
+						<WallTopoViewer
+							topo={props.topo}
+							lines={props.lines}
+							routes={props.routes}
+							singleRouteId={props.routeId}
+						/>
+					)}
+					{props.mode === "route" && <RouteTopoViewer topo={props.topo} />}
+				</div>
+			</div>
+		</div>
+	);
+};

--- a/src/components/molecules/TopoViewer.tsx
+++ b/src/components/molecules/TopoViewer.tsx
@@ -1,0 +1,197 @@
+import { useState } from "react";
+import type { RouteTopo, WallTopo, WallTopoLine } from "@/features/topos/topos.schema";
+
+interface RouteInfo {
+	id: string;
+	name: string;
+	grade: string;
+}
+
+// ── Wall topo viewer (multiple lines, selectable) ─────────────────────────────
+
+interface WallTopoViewerProps {
+	topo: WallTopo;
+	lines: WallTopoLine[];
+	routes: RouteInfo[];
+	/** If set, only this route's line is shown and highlighted (no bottom panel) */
+	singleRouteId?: string;
+}
+
+export const WallTopoViewer = ({
+	topo,
+	lines,
+	routes,
+	singleRouteId,
+}: WallTopoViewerProps) => {
+	const [selectedRouteId, setSelectedRouteId] = useState<string | null>(
+		singleRouteId ?? null,
+	);
+
+	const isSingleMode = singleRouteId !== undefined;
+
+	const visibleLines = isSingleMode
+		? lines.filter((l) => l.route_id === singleRouteId)
+		: lines;
+
+	const selectedRoute = routes.find((r) => r.id === selectedRouteId);
+
+	const pointsStr = (line: WallTopoLine) =>
+		line.points.map((p) => `${p.x_pct * 100},${p.y_pct * 100}`).join(" ");
+
+	return (
+		<div className="flex flex-col w-full h-full">
+			{/* Image + SVG overlay */}
+			<div className="relative w-full flex-1 min-h-0">
+				<img
+					src={topo.image_url}
+					alt="Wall topo"
+					className="w-full h-full object-contain"
+					draggable={false}
+				/>
+				<svg
+					className="absolute inset-0 w-full h-full"
+					viewBox="0 0 100 100"
+					preserveAspectRatio="none"
+					aria-hidden="true"
+				>
+					{visibleLines.map((line) => {
+						const isSelected =
+							selectedRouteId === null || selectedRouteId === line.route_id;
+						const opacity = isSingleMode
+							? 1
+							: selectedRouteId === null
+								? 1
+								: isSelected
+									? 1
+									: 0.5;
+
+						return (
+							<g key={line.id}>
+								{/* Fat invisible hit target */}
+								<polyline
+									points={pointsStr(line)}
+									stroke="transparent"
+									strokeWidth="8"
+									fill="none"
+									style={{ cursor: "pointer" }}
+									onClick={() =>
+										!isSingleMode && setSelectedRouteId(line.route_id)
+									}
+								/>
+								{/* Visible line */}
+								<polyline
+									points={pointsStr(line)}
+									stroke={line.color}
+									strokeWidth="2"
+									fill="none"
+									opacity={opacity}
+									strokeLinecap="round"
+									strokeLinejoin="round"
+									vectorEffect="non-scaling-stroke"
+									style={{ pointerEvents: "none" }}
+								/>
+							</g>
+						);
+					})}
+				</svg>
+			</div>
+
+			{/* Bottom panel — only in multi-route mode */}
+			{!isSingleMode && (
+				<div className="shrink-0 bg-surface-card rounded-b-lg overflow-hidden">
+					{/* Selected route header */}
+					{selectedRoute && (
+						<div className="flex items-center justify-between px-4 py-2 border-b border-border-default">
+							<span className="font-medium text-sm text-text-primary">
+								{selectedRoute.name}
+							</span>
+							<span className="text-xs text-text-secondary">
+								{selectedRoute.grade}
+							</span>
+						</div>
+					)}
+
+					{/* Route list */}
+					<div
+						className="overflow-y-auto"
+						style={{ maxHeight: "40vh", scrollbarWidth: "none" }}
+					>
+						{lines.map((line) => {
+							const route = routes.find((r) => r.id === line.route_id);
+							if (!route) return null;
+							const isActive = selectedRouteId === route.id;
+							return (
+								<button
+									key={line.id}
+									type="button"
+									onClick={() =>
+										setSelectedRouteId(isActive ? null : route.id)
+									}
+									className="w-full flex items-center gap-3 px-4 py-2 text-left hover:bg-surface-page transition-colors"
+								>
+									{/* Color swatch */}
+									<span
+										className="shrink-0 w-3 h-3 rounded-full"
+										style={{
+											backgroundColor: line.color,
+											opacity: isActive || selectedRouteId === null ? 1 : 0.5,
+										}}
+									/>
+									<span
+										className={`flex-1 text-sm ${isActive ? "font-semibold text-text-primary" : "text-text-secondary"}`}
+									>
+										{route.name}
+									</span>
+									<span className="text-xs text-text-tertiary">
+										{route.grade}
+									</span>
+								</button>
+							);
+						})}
+					</div>
+				</div>
+			)}
+		</div>
+	);
+};
+
+// ── Route topo viewer (single line) ──────────────────────────────────────────
+
+interface RouteTopoViewerProps {
+	topo: RouteTopo;
+}
+
+export const RouteTopoViewer = ({ topo }: RouteTopoViewerProps) => {
+	const pointsStr = topo.points
+		.map((p) => `${p.x_pct * 100},${p.y_pct * 100}`)
+		.join(" ");
+
+	return (
+		<div className="relative w-full">
+			<img
+				src={topo.image_url}
+				alt="Route topo"
+				className="w-full object-contain"
+				draggable={false}
+			/>
+			{topo.points.length >= 2 && (
+				<svg
+					className="absolute inset-0 w-full h-full"
+					viewBox="0 0 100 100"
+					preserveAspectRatio="none"
+					aria-hidden="true"
+				>
+					<polyline
+						points={pointsStr}
+						stroke={topo.color}
+						strokeWidth="2"
+						fill="none"
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						vectorEffect="non-scaling-stroke"
+					/>
+				</svg>
+			)}
+		</div>
+	);
+};

--- a/src/components/organisms/TopoBuilder.tsx
+++ b/src/components/organisms/TopoBuilder.tsx
@@ -1,0 +1,715 @@
+import { useRef, useState } from "react";
+import { Spinner } from "@/components/atoms/Spinner";
+import {
+	TOPO_COLORS,
+	type Point,
+	type RouteTopo,
+	type WallTopo,
+	type WallTopoLine,
+	topoColor,
+} from "@/features/topos/topos.schema";
+import {
+	useDeleteRouteTopo,
+	useDeleteWallTopo,
+	useDeleteWallTopoLine,
+	useUploadWallTopoImage,
+	useUpsertRouteTopo,
+	useUpsertWallTopoLine,
+} from "@/features/topos/topos.queries";
+
+// ── Shared SVG drawing canvas ─────────────────────────────────────────────────
+
+const HANDLE_RADIUS = 8; // px — visual handle size (non-scaled)
+const MID_HANDLE_RADIUS = 5;
+const HIT_RADIUS = 24; // px — touch hit area radius
+
+interface DrawingCanvasProps {
+	imageUrl: string;
+	draftPoints: Point[];
+	savedLines: { points: Point[]; color: string; routeId: string }[];
+	activeColor: string;
+	onAddPoint: (p: Point) => void;
+	onMovePoint: (index: number, p: Point) => void;
+	onInsertMidpoint: (afterIndex: number, p: Point) => void;
+}
+
+const DrawingCanvas = ({
+	imageUrl,
+	draftPoints,
+	savedLines,
+	activeColor,
+	onAddPoint,
+	onMovePoint,
+	onInsertMidpoint,
+}: DrawingCanvasProps) => {
+	const containerRef = useRef<HTMLDivElement>(null);
+	// Track which handle is being dragged: { type: 'point' | 'mid', index }
+	const dragRef = useRef<{ type: "point" | "mid"; index: number } | null>(
+		null,
+	);
+
+	const pctFromEvent = (
+		clientX: number,
+		clientY: number,
+	): Point | null => {
+		const el = containerRef.current;
+		if (!el) return null;
+		const rect = el.getBoundingClientRect();
+		return {
+			x_pct: Math.max(0, Math.min(1, (clientX - rect.left) / rect.width)),
+			y_pct: Math.max(0, Math.min(1, (clientY - rect.top) / rect.height)),
+		};
+	};
+
+	const nearestHandle = (
+		clientX: number,
+		clientY: number,
+	): { type: "point" | "mid"; index: number } | null => {
+		const el = containerRef.current;
+		if (!el) return null;
+		const rect = el.getBoundingClientRect();
+		const px = clientX - rect.left;
+		const py = clientY - rect.top;
+
+		// Check existing points first
+		for (let i = 0; i < draftPoints.length; i++) {
+			const hx = draftPoints[i].x_pct * rect.width;
+			const hy = draftPoints[i].y_pct * rect.height;
+			if (Math.hypot(px - hx, py - hy) < HIT_RADIUS) {
+				return { type: "point", index: i };
+			}
+		}
+
+		// Check midpoint handles
+		for (let i = 0; i < draftPoints.length - 1; i++) {
+			const mx =
+				((draftPoints[i].x_pct + draftPoints[i + 1].x_pct) / 2) * rect.width;
+			const my =
+				((draftPoints[i].y_pct + draftPoints[i + 1].y_pct) / 2) * rect.height;
+			if (Math.hypot(px - mx, py - my) < HIT_RADIUS) {
+				return { type: "mid", index: i };
+			}
+		}
+
+		return null;
+	};
+
+	const handleTouchStart = (e: React.TouchEvent) => {
+		if (e.touches.length !== 1) return;
+		const touch = e.touches[0];
+		const hit = nearestHandle(touch.clientX, touch.clientY);
+		if (hit) {
+			dragRef.current = hit;
+			e.preventDefault();
+		}
+	};
+
+	const handleTouchMove = (e: React.TouchEvent) => {
+		if (!dragRef.current || e.touches.length !== 1) return;
+		e.preventDefault();
+		const touch = e.touches[0];
+		const p = pctFromEvent(touch.clientX, touch.clientY);
+		if (!p) return;
+		const drag = dragRef.current;
+		if (drag.type === "point") {
+			onMovePoint(drag.index, p);
+		} else {
+			// Moving a midpoint handle — update to dragged position (will insert on release)
+			dragRef.current = { ...drag };
+		}
+	};
+
+	const handleTouchEnd = (e: React.TouchEvent) => {
+		if (e.changedTouches.length !== 1) return;
+		const touch = e.changedTouches[0];
+		const p = pctFromEvent(touch.clientX, touch.clientY);
+		if (!p) return;
+
+		if (dragRef.current) {
+			const drag = dragRef.current;
+			dragRef.current = null;
+			if (drag.type === "mid") {
+				onInsertMidpoint(drag.index, p);
+			}
+			// point drags are handled live in touchmove; nothing to do on end
+			return;
+		}
+
+		// No drag — it was a tap → add point
+		onAddPoint(p);
+	};
+
+	const handleMouseDown = (e: React.MouseEvent) => {
+		const hit = nearestHandle(e.clientX, e.clientY);
+		if (hit) {
+			dragRef.current = hit;
+		}
+	};
+
+	const handleMouseMove = (e: React.MouseEvent) => {
+		if (!dragRef.current) return;
+		const p = pctFromEvent(e.clientX, e.clientY);
+		if (!p) return;
+		if (dragRef.current.type === "point") {
+			onMovePoint(dragRef.current.index, p);
+		}
+	};
+
+	const handleMouseUp = (e: React.MouseEvent) => {
+		if (!dragRef.current) {
+			// Tap → add point
+			const p = pctFromEvent(e.clientX, e.clientY);
+			if (p) onAddPoint(p);
+			return;
+		}
+		const drag = dragRef.current;
+		dragRef.current = null;
+		if (drag.type === "mid") {
+			const p = pctFromEvent(e.clientX, e.clientY);
+			if (p) onInsertMidpoint(drag.index, p);
+		}
+	};
+
+	const draftPointsStr = draftPoints
+		.map((p) => `${p.x_pct * 100},${p.y_pct * 100}`)
+		.join(" ");
+
+	return (
+		<div
+			ref={containerRef}
+			className="relative w-full select-none"
+			style={{ touchAction: "none", userSelect: "none" }}
+			onTouchStart={handleTouchStart}
+			onTouchMove={handleTouchMove}
+			onTouchEnd={handleTouchEnd}
+			onMouseDown={handleMouseDown}
+			onMouseMove={handleMouseMove}
+			onMouseUp={handleMouseUp}
+		>
+			<img
+				src={imageUrl}
+				alt="Topo background"
+				className="w-full pointer-events-none"
+				draggable={false}
+			/>
+
+			<svg
+				className="absolute inset-0 w-full h-full"
+				viewBox="0 0 100 100"
+				preserveAspectRatio="none"
+				aria-hidden="true"
+			>
+				{/* Saved lines (background, dimmed) */}
+				{savedLines.map((line, i) => (
+					<polyline
+						key={`saved-${i}`}
+						points={line.points.map((p) => `${p.x_pct * 100},${p.y_pct * 100}`).join(" ")}
+						stroke={line.color}
+						strokeWidth="1.5"
+						fill="none"
+						opacity={0.5}
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						vectorEffect="non-scaling-stroke"
+						style={{ pointerEvents: "none" }}
+					/>
+				))}
+
+				{/* Draft line */}
+				{draftPoints.length >= 2 && (
+					<polyline
+						points={draftPointsStr}
+						stroke={activeColor}
+						strokeWidth="2"
+						fill="none"
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						vectorEffect="non-scaling-stroke"
+						style={{ pointerEvents: "none" }}
+					/>
+				)}
+
+				{/* Midpoint handles */}
+				{draftPoints.slice(0, -1).map((pt, i) => {
+					const next = draftPoints[i + 1];
+					const mx = ((pt.x_pct + next.x_pct) / 2) * 100;
+					const my = ((pt.y_pct + next.y_pct) / 2) * 100;
+					return (
+						<circle
+							key={`mid-${i}`}
+							cx={mx}
+							cy={my}
+							r={MID_HANDLE_RADIUS}
+							fill="white"
+							stroke={activeColor}
+							strokeWidth="1.5"
+							opacity={0.8}
+							vectorEffect="non-scaling-stroke"
+							style={{ pointerEvents: "none" }}
+						/>
+					);
+				})}
+
+				{/* Point handles */}
+				{draftPoints.map((pt, i) => (
+					<circle
+						key={`pt-${i}`}
+						cx={pt.x_pct * 100}
+						cy={pt.y_pct * 100}
+						r={HANDLE_RADIUS}
+						fill={i === 0 ? activeColor : "white"}
+						stroke={activeColor}
+						strokeWidth="2"
+						vectorEffect="non-scaling-stroke"
+						style={{ pointerEvents: "none" }}
+					/>
+				))}
+			</svg>
+		</div>
+	);
+};
+
+// ── Wall topo builder ─────────────────────────────────────────────────────────
+
+interface RouteInfo {
+	id: string;
+	name: string;
+	grade: string;
+}
+
+interface WallTopoBuilderProps {
+	wallId: string;
+	routes: RouteInfo[];
+	topo: WallTopo | null;
+	lines: WallTopoLine[];
+}
+
+export const WallTopoBuilder = ({
+	wallId,
+	routes,
+	topo,
+	lines,
+}: WallTopoBuilderProps) => {
+	const fileInputRef = useRef<HTMLInputElement>(null);
+	const [selectedRouteId, setSelectedRouteId] = useState<string>(
+		routes[0]?.id ?? "",
+	);
+	const [draftPoints, setDraftPoints] = useState<Point[]>([]);
+	const [confirmDeleteTopo, setConfirmDeleteTopo] = useState(false);
+	const [confirmDeleteLineId, setConfirmDeleteLineId] = useState<string | null>(
+		null,
+	);
+
+	const uploadImage = useUploadWallTopoImage(wallId);
+	const upsertLine = useUpsertWallTopoLine(wallId);
+	const deleteLine = useDeleteWallTopoLine(topo?.id ?? "");
+	const deleteTopo = useDeleteWallTopo(wallId);
+
+	const selectedRouteIndex = routes.findIndex((r) => r.id === selectedRouteId);
+	const activeColor = topoColor(selectedRouteIndex);
+
+	const savedLines = lines
+		.filter((l) => l.route_id !== selectedRouteId)
+		.map((l) => ({ points: l.points, color: l.color, routeId: l.route_id }));
+
+	const existingLineForRoute = lines.find(
+		(l) => l.route_id === selectedRouteId,
+	);
+
+	const handleSaveLine = () => {
+		if (!topo || draftPoints.length < 2) return;
+		upsertLine.mutate(
+			{
+				topoId: topo.id,
+				routeId: selectedRouteId,
+				points: draftPoints,
+				color: activeColor,
+				sortOrder: selectedRouteIndex,
+			},
+			{ onSuccess: () => setDraftPoints([]) },
+		);
+	};
+
+	if (!topo) {
+		return (
+			<div className="flex flex-col gap-2">
+				<p className="text-sm font-medium text-text-secondary">Topo</p>
+				<button
+					type="button"
+					onClick={() => fileInputRef.current?.click()}
+					disabled={uploadImage.isPending}
+					className="flex items-center justify-center gap-2 rounded-[var(--radius-md)] border-2 border-dashed border-border-default p-6 text-text-tertiary disabled:opacity-50"
+				>
+					{uploadImage.isPending ? <Spinner /> : <span>+ Add topo image</span>}
+				</button>
+				<input
+					ref={fileInputRef}
+					type="file"
+					accept="image/*"
+					className="hidden"
+					onChange={(e) => {
+						const file = e.target.files?.[0];
+						if (file) uploadImage.mutate(file);
+						e.target.value = "";
+					}}
+				/>
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex flex-col gap-3">
+			<div className="flex items-center justify-between">
+				<p className="text-sm font-medium text-text-secondary">Topo</p>
+				<button
+					type="button"
+					onClick={() => setConfirmDeleteTopo(true)}
+					className="text-xs text-red-400"
+				>
+					Delete topo
+				</button>
+			</div>
+
+			{/* Route selector */}
+			{routes.length > 0 && (
+				<div className="flex flex-col gap-1">
+					<label className="text-xs text-text-tertiary">Drawing for:</label>
+					<select
+						value={selectedRouteId}
+						onChange={(e) => {
+							setSelectedRouteId(e.target.value);
+							setDraftPoints([]);
+						}}
+						className="text-sm bg-surface-page text-text-primary rounded-[var(--radius-sm)] px-2 py-1 border border-border-default"
+					>
+						{routes.map((r) => (
+							<option key={r.id} value={r.id}>
+								{r.name} ({r.grade})
+							</option>
+						))}
+					</select>
+					{existingLineForRoute && draftPoints.length === 0 && (
+						<div className="flex items-center justify-between text-xs text-text-tertiary">
+							<span>Line saved — tap to redraw</span>
+							<button
+								type="button"
+								onClick={() => setConfirmDeleteLineId(existingLineForRoute.id)}
+								className="text-red-400"
+							>
+								Remove
+							</button>
+						</div>
+					)}
+				</div>
+			)}
+
+			{/* Drawing canvas */}
+			<DrawingCanvas
+				imageUrl={topo.image_url}
+				draftPoints={draftPoints}
+				savedLines={savedLines}
+				activeColor={activeColor}
+				onAddPoint={(p) => setDraftPoints((pts) => [...pts, p])}
+				onMovePoint={(index, p) =>
+					setDraftPoints((pts) => pts.map((pt, i) => (i === index ? p : pt)))
+				}
+				onInsertMidpoint={(afterIndex, p) =>
+					setDraftPoints((pts) => [
+						...pts.slice(0, afterIndex + 1),
+						p,
+						...pts.slice(afterIndex + 1),
+					])
+				}
+			/>
+
+			{/* Drawing controls */}
+			{draftPoints.length > 0 && (
+				<div className="flex gap-2">
+					<button
+						type="button"
+						onClick={() => setDraftPoints((pts) => pts.slice(0, -1))}
+						className="flex-1 py-2 text-sm rounded-[var(--radius-md)] border border-border-default text-text-secondary"
+					>
+						Undo
+					</button>
+					<button
+						type="button"
+						onClick={() => setDraftPoints([])}
+						className="flex-1 py-2 text-sm rounded-[var(--radius-md)] border border-border-default text-text-secondary"
+					>
+						Clear
+					</button>
+					<button
+						type="button"
+						disabled={draftPoints.length < 2 || upsertLine.isPending}
+						onClick={handleSaveLine}
+						className="flex-1 py-2 text-sm rounded-[var(--radius-md)] bg-accent-primary text-white font-medium disabled:opacity-50"
+					>
+						{upsertLine.isPending ? <Spinner /> : "Save line"}
+					</button>
+				</div>
+			)}
+
+			{/* Color legend */}
+			{lines.length > 0 && (
+				<div className="flex flex-wrap gap-2">
+					{lines.map((line) => {
+						const route = routes.find((r) => r.id === line.route_id);
+						if (!route) return null;
+						return (
+							<span
+								key={line.id}
+								className="flex items-center gap-1 text-xs text-text-secondary"
+							>
+								<span
+									className="inline-block w-2.5 h-2.5 rounded-full"
+									style={{ backgroundColor: line.color }}
+								/>
+								{route.name}
+							</span>
+						);
+					})}
+				</div>
+			)}
+
+			{/* Confirm delete topo */}
+			{confirmDeleteTopo && (
+				<div className="fixed inset-0 z-50 flex items-end justify-center bg-black/40">
+					<div className="bg-surface-card rounded-t-2xl p-6 w-full flex flex-col gap-3">
+						<p className="text-text-primary font-medium text-center">
+							Delete topo and all route lines?
+						</p>
+						<button
+							type="button"
+							onClick={() => {
+								deleteTopo.mutate({ id: topo.id, imageUrl: topo.image_url });
+								setConfirmDeleteTopo(false);
+								setDraftPoints([]);
+							}}
+							className="w-full py-3 rounded-[var(--radius-md)] bg-red-500 text-white font-medium"
+						>
+							Delete
+						</button>
+						<button
+							type="button"
+							onClick={() => setConfirmDeleteTopo(false)}
+							className="w-full py-2 text-text-secondary"
+						>
+							Cancel
+						</button>
+					</div>
+				</div>
+			)}
+
+			{/* Confirm delete line */}
+			{confirmDeleteLineId && (
+				<div className="fixed inset-0 z-50 flex items-end justify-center bg-black/40">
+					<div className="bg-surface-card rounded-t-2xl p-6 w-full flex flex-col gap-3">
+						<p className="text-text-primary font-medium text-center">
+							Remove this route line?
+						</p>
+						<button
+							type="button"
+							onClick={() => {
+								deleteLine.mutate(confirmDeleteLineId);
+								setConfirmDeleteLineId(null);
+							}}
+							className="w-full py-3 rounded-[var(--radius-md)] bg-red-500 text-white font-medium"
+						>
+							Remove
+						</button>
+						<button
+							type="button"
+							onClick={() => setConfirmDeleteLineId(null)}
+							className="w-full py-2 text-text-secondary"
+						>
+							Cancel
+						</button>
+					</div>
+				</div>
+			)}
+		</div>
+	);
+};
+
+// ── Route topo builder ────────────────────────────────────────────────────────
+
+interface RouteTopoBuilderProps {
+	routeId: string;
+	topo: RouteTopo | null;
+}
+
+export const RouteTopoBuilder = ({ routeId, topo }: RouteTopoBuilderProps) => {
+	const fileInputRef = useRef<HTMLInputElement>(null);
+	const [draftPoints, setDraftPoints] = useState<Point[]>(
+		topo?.points ?? [],
+	);
+	const [pendingFile, setPendingFile] = useState<File | null>(null);
+	const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+	const [confirmDelete, setConfirmDelete] = useState(false);
+
+	const upsertTopo = useUpsertRouteTopo(routeId);
+	const deleteTopo = useDeleteRouteTopo(routeId);
+
+	const imageUrl = previewUrl ?? topo?.image_url ?? null;
+	const color = TOPO_COLORS[0];
+
+	const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		const file = e.target.files?.[0];
+		if (!file) return;
+		setPendingFile(file);
+		setPreviewUrl(URL.createObjectURL(file));
+		setDraftPoints([]);
+		e.target.value = "";
+	};
+
+	const handleSave = () => {
+		upsertTopo.mutate(
+			{ file: pendingFile, points: draftPoints, color },
+			{
+				onSuccess: () => {
+					setPendingFile(null);
+					if (previewUrl) URL.revokeObjectURL(previewUrl);
+					setPreviewUrl(null);
+				},
+			},
+		);
+	};
+
+	if (!imageUrl) {
+		return (
+			<div className="flex flex-col gap-2">
+				<p className="text-sm font-medium text-text-secondary">Route topo</p>
+				<button
+					type="button"
+					onClick={() => fileInputRef.current?.click()}
+					className="flex items-center justify-center gap-2 rounded-[var(--radius-md)] border-2 border-dashed border-border-default p-6 text-text-tertiary"
+				>
+					+ Add topo image
+				</button>
+				<input
+					ref={fileInputRef}
+					type="file"
+					accept="image/*"
+					className="hidden"
+					onChange={handleFileChange}
+				/>
+			</div>
+		);
+	}
+
+	const isDirty =
+		pendingFile !== null ||
+		JSON.stringify(draftPoints) !== JSON.stringify(topo?.points ?? []);
+
+	return (
+		<div className="flex flex-col gap-3">
+			<div className="flex items-center justify-between">
+				<p className="text-sm font-medium text-text-secondary">Route topo</p>
+				<div className="flex gap-3">
+					<button
+						type="button"
+						onClick={() => fileInputRef.current?.click()}
+						className="text-xs text-accent-primary"
+					>
+						Change image
+					</button>
+					{topo && (
+						<button
+							type="button"
+							onClick={() => setConfirmDelete(true)}
+							className="text-xs text-red-400"
+						>
+							Delete
+						</button>
+					)}
+				</div>
+			</div>
+
+			<input
+				ref={fileInputRef}
+				type="file"
+				accept="image/*"
+				className="hidden"
+				onChange={handleFileChange}
+			/>
+
+			<DrawingCanvas
+				imageUrl={imageUrl}
+				draftPoints={draftPoints}
+				savedLines={[]}
+				activeColor={color}
+				onAddPoint={(p) => setDraftPoints((pts) => [...pts, p])}
+				onMovePoint={(index, p) =>
+					setDraftPoints((pts) => pts.map((pt, i) => (i === index ? p : pt)))
+				}
+				onInsertMidpoint={(afterIndex, p) =>
+					setDraftPoints((pts) => [
+						...pts.slice(0, afterIndex + 1),
+						p,
+						...pts.slice(afterIndex + 1),
+					])
+				}
+			/>
+
+			{draftPoints.length > 0 && (
+				<div className="flex gap-2">
+					<button
+						type="button"
+						onClick={() => setDraftPoints((pts) => pts.slice(0, -1))}
+						className="flex-1 py-2 text-sm rounded-[var(--radius-md)] border border-border-default text-text-secondary"
+					>
+						Undo
+					</button>
+					<button
+						type="button"
+						onClick={() => setDraftPoints([])}
+						className="flex-1 py-2 text-sm rounded-[var(--radius-md)] border border-border-default text-text-secondary"
+					>
+						Clear
+					</button>
+				</div>
+			)}
+
+			{isDirty && (
+				<button
+					type="button"
+					disabled={upsertTopo.isPending || draftPoints.length < 2}
+					onClick={handleSave}
+					className="w-full py-2.5 text-sm rounded-[var(--radius-md)] bg-accent-primary text-white font-medium disabled:opacity-50"
+				>
+					{upsertTopo.isPending ? <Spinner /> : "Save topo"}
+				</button>
+			)}
+
+			{/* Confirm delete */}
+			{confirmDelete && topo && (
+				<div className="fixed inset-0 z-50 flex items-end justify-center bg-black/40">
+					<div className="bg-surface-card rounded-t-2xl p-6 w-full flex flex-col gap-3">
+						<p className="text-text-primary font-medium text-center">
+							Delete this route topo?
+						</p>
+						<button
+							type="button"
+							onClick={() => {
+								deleteTopo.mutate({ id: topo.id, imageUrl: topo.image_url });
+								setConfirmDelete(false);
+								setDraftPoints([]);
+							}}
+							className="w-full py-3 rounded-[var(--radius-md)] bg-red-500 text-white font-medium"
+						>
+							Delete
+						</button>
+						<button
+							type="button"
+							onClick={() => setConfirmDelete(false)}
+							className="w-full py-2 text-text-secondary"
+						>
+							Cancel
+						</button>
+					</div>
+				</div>
+			)}
+		</div>
+	);
+};

--- a/src/features/topos/README.md
+++ b/src/features/topos/README.md
@@ -1,0 +1,67 @@
+# Topos Feature
+
+Admin-managed climbing route topo photos with drawn route lines. All users can view topos; only admins can create and edit them.
+
+## Concepts
+
+- **Wall topo** — one photo per wall with multiple route lines drawn on it (one per route). Lines are stored as arrays of `{x_pct, y_pct}` points (0–1 normalized to image dimensions).
+- **Route topo** — an optional separate close-up photo for an individual route with a single route line. Falls back to the wall topo (filtered to that route's line) when no dedicated topo exists.
+
+## Schema
+
+### TypeScript
+
+```ts
+Point         = { x_pct: number, y_pct: number }  // 0-1 normalized
+WallTopo      = { id, wall_id, image_url, created_by, created_at }
+WallTopoLine  = { id, topo_id, route_id, points: Point[], color, sort_order, created_at }
+RouteTopo     = { id, route_id, image_url, points: Point[], color, created_by, created_at }
+```
+
+### SQLite (migration v19)
+
+| Table | Key columns |
+|---|---|
+| `wall_topos_cache` | `id`, `wall_id`, `image_url`, `created_by` |
+| `wall_topo_lines_cache` | `id`, `topo_id`, `route_id`, `points` (JSON), `color`, `sort_order` |
+| `route_topos_cache` | `id`, `route_id`, `image_url`, `points` (JSON), `color`, `created_by` |
+
+### Supabase tables
+
+Mirror the SQLite schema: `wall_topos`, `wall_topo_lines`, `route_topos`.
+
+**Storage:** `route-images` bucket under `topos/walls/{wallId}/{uuid}.jpg` and `topos/routes/{routeId}/{uuid}.jpg`.
+
+**RLS:** authenticated SELECT; admin-only INSERT/UPDATE/DELETE.
+
+## Service functions (`topos.service.ts`)
+
+| Function | Description |
+|---|---|
+| `fetchWallTopo(wallId)` | Get wall topo from local cache |
+| `fetchWallTopoLines(topoId)` | Get all lines for a topo, JSON points parsed |
+| `fetchRouteTopo(routeId)` | Get route topo from local cache |
+| `upsertWallTopo(wallId, imageUrl, createdBy)` | Create or update wall topo in Supabase + cache |
+| `upsertWallTopoLine(topoId, routeId, points, color, sortOrder)` | Create or update a route line |
+| `deleteWallTopoLine(id)` | Remove a route line |
+| `deleteWallTopo(id, imageUrl)` | Remove topo + all lines + storage file |
+| `upsertRouteTopo(routeId, imageUrl, points, color, createdBy)` | Create or update route topo |
+| `deleteRouteTopo(id, imageUrl)` | Remove route topo + storage file |
+
+## Query hooks (`topos.queries.ts`)
+
+| Hook | Purpose |
+|---|---|
+| `useWallTopo(wallId)` | Fetch wall topo |
+| `useWallTopoLines(topoId)` | Fetch wall topo lines |
+| `useRouteTopo(routeId)` | Fetch route topo |
+| `useUploadWallTopoImage(wallId)` | Upload image and create/update wall topo |
+| `useUpsertWallTopoLine(wallId)` | Save a route line |
+| `useDeleteWallTopoLine(topoId)` | Delete a route line |
+| `useDeleteWallTopo(wallId)` | Delete entire wall topo |
+| `useUpsertRouteTopo(routeId)` | Save route topo (image + points) |
+| `useDeleteRouteTopo(routeId)` | Delete route topo |
+
+## Colors
+
+Fixed palette of 8 colors (`TOPO_COLORS`), assigned by route sort_order index mod 8 via `topoColor(index)`.

--- a/src/features/topos/topos.queries.ts
+++ b/src/features/topos/topos.queries.ts
@@ -1,0 +1,181 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useAuthStore } from "@/features/auth/auth.store";
+import { uploadToStorage } from "@/lib/image-utils";
+import { supabase } from "@/lib/supabase";
+import type { Point } from "./topos.schema";
+import {
+	deleteRouteTopo,
+	deleteWallTopo,
+	deleteWallTopoLine,
+	fetchRouteTopo,
+	fetchWallTopo,
+	fetchWallTopoLines,
+	upsertRouteTopo,
+	upsertWallTopo,
+	upsertWallTopoLine,
+} from "./topos.service";
+
+const WALL_TOPO_KEY = "wall-topo";
+const WALL_TOPO_LINES_KEY = "wall-topo-lines";
+const ROUTE_TOPO_KEY = "route-topo";
+
+// ── Wall topo ─────────────────────────────────────────────────────────────────
+
+export function useWallTopo(wallId: string | null) {
+	return useQuery({
+		queryKey: [WALL_TOPO_KEY, wallId],
+		queryFn: () => fetchWallTopo(wallId!),
+		enabled: !!wallId,
+	});
+}
+
+export function useWallTopoLines(topoId: string | null) {
+	return useQuery({
+		queryKey: [WALL_TOPO_LINES_KEY, topoId],
+		queryFn: () => fetchWallTopoLines(topoId!),
+		enabled: !!topoId,
+	});
+}
+
+export function useUploadWallTopoImage(wallId: string) {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: async (file: File) => {
+			const user = useAuthStore.getState().user;
+			if (!user) throw new Error("Not authenticated");
+
+			const storagePath = await uploadToStorage(
+				"route-images",
+				`topos/walls/${wallId}/${crypto.randomUUID()}.jpg`,
+				file,
+			);
+			const { data } = supabase.storage
+				.from("route-images")
+				.getPublicUrl(storagePath);
+
+			await upsertWallTopo(wallId, data.publicUrl, user.id);
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: [WALL_TOPO_KEY, wallId] });
+		},
+	});
+}
+
+export function useDeleteWallTopo(wallId: string) {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: ({ id, imageUrl }: { id: string; imageUrl: string }) =>
+			deleteWallTopo(id, imageUrl),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: [WALL_TOPO_KEY, wallId] });
+			queryClient.invalidateQueries({ queryKey: [WALL_TOPO_LINES_KEY] });
+		},
+	});
+}
+
+export function useUpsertWallTopoLine(wallId: string) {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: ({
+			topoId,
+			routeId,
+			points,
+			color,
+			sortOrder,
+		}: {
+			topoId: string;
+			routeId: string;
+			points: Point[];
+			color: string;
+			sortOrder: number;
+		}) => upsertWallTopoLine(topoId, routeId, points, color, sortOrder),
+		onSuccess: (_data, { topoId }: { topoId: string; routeId: string; points: Point[]; color: string; sortOrder: number }) => {
+			queryClient.invalidateQueries({
+				queryKey: [WALL_TOPO_LINES_KEY, topoId],
+			});
+			// Also invalidate route topo queries so fallback display updates
+			queryClient.invalidateQueries({ queryKey: [WALL_TOPO_KEY, wallId] });
+		},
+	});
+}
+
+export function useDeleteWallTopoLine(topoId: string) {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: (id: string) => deleteWallTopoLine(id),
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: [WALL_TOPO_LINES_KEY, topoId],
+			});
+		},
+	});
+}
+
+// ── Route topo ────────────────────────────────────────────────────────────────
+
+export function useRouteTopo(routeId: string | null) {
+	return useQuery({
+		queryKey: [ROUTE_TOPO_KEY, routeId],
+		queryFn: () => fetchRouteTopo(routeId!),
+		enabled: !!routeId,
+	});
+}
+
+export function useUpsertRouteTopo(routeId: string) {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: async ({
+			file,
+			points,
+			color,
+		}: {
+			file: File | null;
+			points: Point[];
+			color: string;
+		}) => {
+			const user = useAuthStore.getState().user;
+			if (!user) throw new Error("Not authenticated");
+
+			let imageUrl: string;
+
+			if (file) {
+				const storagePath = await uploadToStorage(
+					"route-images",
+					`topos/routes/${routeId}/${crypto.randomUUID()}.jpg`,
+					file,
+				);
+				const { data } = supabase.storage
+					.from("route-images")
+					.getPublicUrl(storagePath);
+				imageUrl = data.publicUrl;
+			} else {
+				// Updating points only — get existing URL
+				const existing = await fetchRouteTopo(routeId);
+				if (!existing) throw new Error("No topo image to update");
+				imageUrl = existing.image_url;
+			}
+
+			await upsertRouteTopo(routeId, imageUrl, points, color, user.id);
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: [ROUTE_TOPO_KEY, routeId] });
+		},
+	});
+}
+
+export function useDeleteRouteTopo(routeId: string) {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: ({ id, imageUrl }: { id: string; imageUrl: string }) =>
+			deleteRouteTopo(id, imageUrl),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: [ROUTE_TOPO_KEY, routeId] });
+		},
+	});
+}

--- a/src/features/topos/topos.schema.ts
+++ b/src/features/topos/topos.schema.ts
@@ -1,0 +1,54 @@
+import { z } from "zod/v4";
+
+export const PointSchema = z.object({
+	x_pct: z.number().min(0).max(1),
+	y_pct: z.number().min(0).max(1),
+});
+export type Point = z.infer<typeof PointSchema>;
+
+export const WallTopoSchema = z.object({
+	id: z.string(),
+	wall_id: z.string(),
+	image_url: z.string(),
+	created_by: z.string().nullable(),
+	created_at: z.string(),
+});
+export type WallTopo = z.infer<typeof WallTopoSchema>;
+
+export const WallTopoLineSchema = z.object({
+	id: z.string(),
+	topo_id: z.string(),
+	route_id: z.string(),
+	points: z.array(PointSchema),
+	color: z.string(),
+	sort_order: z.number(),
+	created_at: z.string(),
+});
+export type WallTopoLine = z.infer<typeof WallTopoLineSchema>;
+
+export const RouteTopoSchema = z.object({
+	id: z.string(),
+	route_id: z.string(),
+	image_url: z.string(),
+	points: z.array(PointSchema),
+	color: z.string(),
+	created_by: z.string().nullable(),
+	created_at: z.string(),
+});
+export type RouteTopo = z.infer<typeof RouteTopoSchema>;
+
+/** Fixed color palette — assigned by route sort_order index mod palette length */
+export const TOPO_COLORS = [
+	"#EF4444",
+	"#F97316",
+	"#EAB308",
+	"#22C55E",
+	"#06B6D4",
+	"#6366F1",
+	"#EC4899",
+	"#A78BFA",
+] as const;
+
+export function topoColor(index: number): string {
+	return TOPO_COLORS[index % TOPO_COLORS.length];
+}

--- a/src/features/topos/topos.service.ts
+++ b/src/features/topos/topos.service.ts
@@ -1,0 +1,229 @@
+import { getDb } from "@/lib/db";
+import { supabase } from "@/lib/supabase";
+import type { Point, RouteTopo, WallTopo, WallTopoLine } from "./topos.schema";
+
+// ── Wall topos ────────────────────────────────────────────────────────────────
+
+export async function fetchWallTopo(
+	wallId: string,
+): Promise<WallTopo | null> {
+	const db = await getDb();
+	const rows = await db.select<WallTopo[]>(
+		"SELECT * FROM wall_topos_cache WHERE wall_id = ? LIMIT 1",
+		[wallId],
+	);
+	return rows[0] ?? null;
+}
+
+export async function upsertWallTopo(
+	wallId: string,
+	imageUrl: string,
+	createdBy: string,
+): Promise<string> {
+	const db = await getDb();
+
+	// Only one topo per wall — check for existing
+	const existing = await fetchWallTopo(wallId);
+	if (existing) {
+		// Update image url
+		await supabase
+			.from("wall_topos")
+			.update({ image_url: imageUrl })
+			.eq("id", existing.id);
+		await db.execute(
+			"UPDATE wall_topos_cache SET image_url = ? WHERE id = ?",
+			[imageUrl, existing.id],
+		);
+		return existing.id;
+	}
+
+	const id = crypto.randomUUID();
+	const now = new Date().toISOString();
+	await supabase.from("wall_topos").insert({
+		id,
+		wall_id: wallId,
+		image_url: imageUrl,
+		created_by: createdBy,
+		created_at: now,
+	});
+	await db.execute(
+		`INSERT INTO wall_topos_cache (id, wall_id, image_url, created_by, created_at)
+     VALUES (?, ?, ?, ?, ?)`,
+		[id, wallId, imageUrl, createdBy, now],
+	);
+	return id;
+}
+
+export async function deleteWallTopo(
+	id: string,
+	imageUrl: string,
+): Promise<void> {
+	const db = await getDb();
+	// Delete all lines first
+	await supabase.from("wall_topo_lines").delete().eq("topo_id", id);
+	await db.execute("DELETE FROM wall_topo_lines_cache WHERE topo_id = ?", [
+		id,
+	]);
+	await supabase.from("wall_topos").delete().eq("id", id);
+	await db.execute("DELETE FROM wall_topos_cache WHERE id = ?", [id]);
+	// Remove from storage
+	const marker = "/storage/v1/object/public/route-images/";
+	const storagePath = imageUrl.includes(marker)
+		? imageUrl.split(marker)[1]
+		: null;
+	if (storagePath) {
+		await supabase.storage.from("route-images").remove([storagePath]);
+	}
+}
+
+// ── Wall topo lines ───────────────────────────────────────────────────────────
+
+type WallTopoLineRow = Omit<WallTopoLine, "points"> & { points: string };
+
+export async function fetchWallTopoLines(
+	topoId: string,
+): Promise<WallTopoLine[]> {
+	const db = await getDb();
+	const rows = await db.select<WallTopoLineRow[]>(
+		"SELECT * FROM wall_topo_lines_cache WHERE topo_id = ? ORDER BY sort_order ASC",
+		[topoId],
+	);
+	return rows.map((r) => ({
+		...r,
+		points: JSON.parse(r.points) as Point[],
+	}));
+}
+
+export async function upsertWallTopoLine(
+	topoId: string,
+	routeId: string,
+	points: Point[],
+	color: string,
+	sortOrder: number,
+): Promise<string> {
+	const db = await getDb();
+	const pointsJson = JSON.stringify(points);
+
+	// Check if a line for this route already exists on this topo
+	const existing = await db.select<{ id: string }[]>(
+		"SELECT id FROM wall_topo_lines_cache WHERE topo_id = ? AND route_id = ? LIMIT 1",
+		[topoId, routeId],
+	);
+
+	if (existing[0]) {
+		const lineId = existing[0].id;
+		await supabase
+			.from("wall_topo_lines")
+			.upsert({
+				id: lineId,
+				topo_id: topoId,
+				route_id: routeId,
+				points: pointsJson,
+				color,
+				sort_order: sortOrder,
+			});
+		await db.execute(
+			`UPDATE wall_topo_lines_cache SET points = ?, color = ?, sort_order = ? WHERE id = ?`,
+			[pointsJson, color, sortOrder, lineId],
+		);
+		return lineId;
+	}
+
+	const id = crypto.randomUUID();
+	const now = new Date().toISOString();
+	await supabase.from("wall_topo_lines").insert({
+		id,
+		topo_id: topoId,
+		route_id: routeId,
+		points: pointsJson,
+		color,
+		sort_order: sortOrder,
+		created_at: now,
+	});
+	await db.execute(
+		`INSERT INTO wall_topo_lines_cache (id, topo_id, route_id, points, color, sort_order, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		[id, topoId, routeId, pointsJson, color, sortOrder, now],
+	);
+	return id;
+}
+
+export async function deleteWallTopoLine(id: string): Promise<void> {
+	const db = await getDb();
+	await supabase.from("wall_topo_lines").delete().eq("id", id);
+	await db.execute("DELETE FROM wall_topo_lines_cache WHERE id = ?", [id]);
+}
+
+// ── Route topos ───────────────────────────────────────────────────────────────
+
+type RouteTopoRow = Omit<RouteTopo, "points"> & { points: string };
+
+export async function fetchRouteTopo(
+	routeId: string,
+): Promise<RouteTopo | null> {
+	const db = await getDb();
+	const rows = await db.select<RouteTopoRow[]>(
+		"SELECT * FROM route_topos_cache WHERE route_id = ? LIMIT 1",
+		[routeId],
+	);
+	if (!rows[0]) return null;
+	return { ...rows[0], points: JSON.parse(rows[0].points) as Point[] };
+}
+
+export async function upsertRouteTopo(
+	routeId: string,
+	imageUrl: string,
+	points: Point[],
+	color: string,
+	createdBy: string,
+): Promise<string> {
+	const db = await getDb();
+	const pointsJson = JSON.stringify(points);
+
+	const existing = await fetchRouteTopo(routeId);
+	if (existing) {
+		await supabase
+			.from("route_topos")
+			.update({ image_url: imageUrl, points: pointsJson, color })
+			.eq("id", existing.id);
+		await db.execute(
+			"UPDATE route_topos_cache SET image_url = ?, points = ?, color = ? WHERE id = ?",
+			[imageUrl, pointsJson, color, existing.id],
+		);
+		return existing.id;
+	}
+
+	const id = crypto.randomUUID();
+	const now = new Date().toISOString();
+	await supabase.from("route_topos").insert({
+		id,
+		route_id: routeId,
+		image_url: imageUrl,
+		points: pointsJson,
+		color,
+		created_by: createdBy,
+		created_at: now,
+	});
+	await db.execute(
+		`INSERT INTO route_topos_cache (id, route_id, image_url, points, color, created_by, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		[id, routeId, imageUrl, pointsJson, color, createdBy, now],
+	);
+	return id;
+}
+
+export async function deleteRouteTopo(
+	id: string,
+	imageUrl: string,
+): Promise<void> {
+	const db = await getDb();
+	await supabase.from("route_topos").delete().eq("id", id);
+	await db.execute("DELETE FROM route_topos_cache WHERE id = ?", [id]);
+	const marker = "/storage/v1/object/public/route-images/";
+	const storagePath = imageUrl.includes(marker)
+		? imageUrl.split(marker)[1]
+		: null;
+	if (storagePath) {
+		await supabase.storage.from("route-images").remove([storagePath]);
+	}
+}

--- a/src/lib/README.md
+++ b/src/lib/README.md
@@ -42,6 +42,9 @@ Versioned migration runner. Maintains a `schema_version` table (single row) and 
 | `route_images_cache` | Admin-managed route photos (read-only cache) (#11) |
 | `wall_images_cache` | Admin-managed wall photos (read-only cache) (#11) |
 | `climb_images` | User-uploaded photos per climb log entry (#12) |
+| `wall_topos_cache` | Admin-managed wall topo photos (one per wall) |
+| `wall_topo_lines_cache` | Route lines on wall topos; `points` stored as JSON `[{x_pct,y_pct}]` |
+| `route_topos_cache` | Admin-managed route topo photos (one per route, optional) |
 
 ### Migration history
 
@@ -65,6 +68,7 @@ Versioned migration runner. Maintains a `schema_version` table (single row) and 
 | v16 | `pointer_dir` on `climb_image_pins` (#38) |
 | v17 | Backfill `server_updated_at` on `downloaded_regions` for devices that skipped v15 |
 | v18 | `crag`, `wall` on `climbs` — full 5-level location breadcrumb (#44) |
+| v19 | `wall_topos_cache`, `wall_topo_lines_cache`, `route_topos_cache` tables for topo photos |
 
 ### Rules
 - Always use `?` positional parameters — never string interpolation (SQL injection)

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -434,6 +434,41 @@ const migrations: Migration[] = [
 			await db.execute(`ALTER TABLE climbs ADD COLUMN wall TEXT`);
 		}
 	},
+
+	// v19: topo tables for wall and route topos
+	async (db) => {
+		await db.execute(`
+      CREATE TABLE IF NOT EXISTS wall_topos_cache (
+        id         TEXT PRIMARY KEY,
+        wall_id    TEXT NOT NULL,
+        image_url  TEXT NOT NULL,
+        created_by TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      )
+    `);
+		await db.execute(`
+      CREATE TABLE IF NOT EXISTS wall_topo_lines_cache (
+        id         TEXT PRIMARY KEY,
+        topo_id    TEXT NOT NULL,
+        route_id   TEXT NOT NULL,
+        points     TEXT NOT NULL,
+        color      TEXT NOT NULL,
+        sort_order INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      )
+    `);
+		await db.execute(`
+      CREATE TABLE IF NOT EXISTS route_topos_cache (
+        id         TEXT PRIMARY KEY,
+        route_id   TEXT NOT NULL,
+        image_url  TEXT NOT NULL,
+        points     TEXT NOT NULL,
+        color      TEXT NOT NULL DEFAULT '#EF4444',
+        created_by TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      )
+    `);
+	},
 ];
 
 export async function runMigrations(db: DbAdapter): Promise<void> {

--- a/src/views/RouteDetailView.tsx
+++ b/src/views/RouteDetailView.tsx
@@ -8,7 +8,14 @@ import { Spinner } from "@/components/atoms/Spinner";
 import { AdminImageGallery } from "@/components/molecules/AdminImageGallery";
 import { EditableDescription } from "@/components/molecules/EditableDescription";
 import { RouteBodyChart } from "@/components/molecules/RouteBodyChart";
+import { TopoModal } from "@/components/molecules/TopoModal";
+import { RouteTopoBuilder } from "@/components/organisms/TopoBuilder";
 import { useAuthStore } from "@/features/auth/auth.store";
+import {
+	useRouteTopo,
+	useWallTopo,
+	useWallTopoLines,
+} from "@/features/topos/topos.queries";
 import { useClimbs } from "@/features/climbs/climbs.queries";
 import {
 	useAddRouteImage,
@@ -39,6 +46,14 @@ const RouteDetailView = () => {
 	const user = useAuthStore((s) => s.user);
 	const isAdmin = user?.role === "admin";
 	const existingClimb = climbs.find((c) => c.route_id === routeId);
+
+	// Topo data
+	const { data: routeTopo = null } = useRouteTopo(routeId);
+	const { data: wallTopo = null } = useWallTopo(route?.wall_id ?? null);
+	const { data: wallTopoLines = [] } = useWallTopoLines(wallTopo?.id ?? null);
+	const wallTopoLineForRoute = wallTopoLines.find((l) => l.route_id === routeId);
+	const showWallTopoFallback = !routeTopo && !!wallTopo && !!wallTopoLineForRoute;
+	const [showTopoModal, setShowTopoModal] = useState(false);
 
 	const [linkUrl, setLinkUrl] = useState("");
 	const [linkTitle, setLinkTitle] = useState("");
@@ -130,6 +145,51 @@ const RouteDetailView = () => {
 				onDelete={(id, imageUrl) => deleteRouteImage.mutate({ id, imageUrl })}
 				isAdding={addRouteImage.isPending}
 			/>
+
+			{/* Topo section */}
+			{(routeTopo || showWallTopoFallback) && (
+				<div className="flex flex-col gap-1">
+					<p className="text-xs text-text-tertiary">Topo</p>
+					<button
+						type="button"
+						onClick={() => setShowTopoModal(true)}
+						className="relative w-full rounded-[var(--radius-md)] overflow-hidden"
+						aria-label="View topo"
+					>
+						<img
+							src={routeTopo ? routeTopo.image_url : wallTopo!.image_url}
+							alt="Route topo"
+							className="w-full object-cover max-h-40"
+						/>
+						<span className="absolute inset-0 flex items-center justify-center bg-black/20 text-white text-xs font-medium">
+							View topo
+						</span>
+					</button>
+				</div>
+			)}
+
+			{isAdmin && (
+				<RouteTopoBuilder routeId={routeId} topo={routeTopo} />
+			)}
+
+			{showTopoModal && routeTopo && (
+				<TopoModal
+					mode="route"
+					topo={routeTopo}
+					onClose={() => setShowTopoModal(false)}
+				/>
+			)}
+
+			{showTopoModal && showWallTopoFallback && wallTopo && wallTopoLineForRoute && (
+				<TopoModal
+					mode="wall-single"
+					topo={wallTopo}
+					lines={wallTopoLines}
+					routes={route ? [{ id: route.id, name: route.name, grade: route.grade }] : []}
+					routeId={routeId}
+					onClose={() => setShowTopoModal(false)}
+				/>
+			)}
 
 			{/* Links section */}
 			<div className="flex flex-col gap-2">

--- a/src/views/WallView.tsx
+++ b/src/views/WallView.tsx
@@ -9,6 +9,8 @@ import {
 	type PickerMarker,
 } from "@/components/molecules/CoordinatePicker";
 import { EditableDescription } from "@/components/molecules/EditableDescription";
+import { TopoModal } from "@/components/molecules/TopoModal";
+import { WallTopoBuilder } from "@/components/organisms/TopoBuilder";
 import { useAuthStore } from "@/features/auth/auth.store";
 import {
 	useAdminUpdateWallCoords,
@@ -23,6 +25,10 @@ import {
 	useDeleteWallImage,
 	useWallImages,
 } from "@/features/route-images/route-images.queries";
+import {
+	useWallTopo,
+	useWallTopoLines,
+} from "@/features/topos/topos.queries";
 import { useRoutes } from "@/features/routes/routes.queries";
 
 const ViewOnMap = ({ lat, lng }: { lat: number; lng: number }) => {
@@ -59,6 +65,9 @@ const WallView = () => {
 	const deleteWallImage = useDeleteWallImage(wallId);
 	const isAdmin = useAuthStore((s) => s.user?.role === "admin");
 	const [showCoordEditor, setShowCoordEditor] = useState(false);
+	const [showTopoModal, setShowTopoModal] = useState(false);
+	const { data: wallTopo = null } = useWallTopo(wallId);
+	const { data: wallTopoLines = [] } = useWallTopoLines(wallTopo?.id ?? null);
 
 	const siblingMarkers = useMemo<PickerMarker[]>(() => {
 		const result: PickerMarker[] = [];
@@ -140,6 +149,49 @@ const WallView = () => {
 				onDelete={(id, imageUrl) => deleteWallImage.mutate({ id, imageUrl })}
 				isAdding={addWallImage.isPending}
 			/>
+
+			{/* Topo section */}
+			{wallTopo && (
+				<div className="flex flex-col gap-1">
+					<p className="text-xs text-text-tertiary">Topo</p>
+					<button
+						type="button"
+						onClick={() => setShowTopoModal(true)}
+						className="relative w-full rounded-[var(--radius-md)] overflow-hidden"
+						aria-label="View topo"
+					>
+						<img
+							src={wallTopo.image_url}
+							alt="Wall topo"
+							className="w-full object-cover max-h-40"
+						/>
+						<span className="absolute inset-0 flex items-center justify-center bg-black/20 text-white text-xs font-medium">
+							View topo
+						</span>
+					</button>
+				</div>
+			)}
+
+			{isAdmin && (
+				<WallTopoBuilder
+					wallId={wallId}
+					routes={routes.filter((r) => r.status === "verified")}
+					topo={wallTopo}
+					lines={wallTopoLines}
+				/>
+			)}
+
+			{showTopoModal && wallTopo && (
+				<TopoModal
+					mode="wall"
+					topo={wallTopo}
+					lines={wallTopoLines}
+					routes={routes
+						.filter((r) => r.status === "verified")
+						.map((r) => ({ id: r.id, name: r.name, grade: r.grade }))}
+					onClose={() => setShowTopoModal(false)}
+				/>
+			)}
 
 			{wall.lat != null && wall.lng != null && (
 				<ViewOnMap lat={wall.lat} lng={wall.lng} />


### PR DESCRIPTION
Admin-only topo builder lets admins upload a wall photo and draw
polyline route lines on it using tap-to-add and drag-midpoint-to-insert
interactions. Viewers can tap any line or the route list to highlight a
single route (others dim to 50% opacity). Route detail pages fall back
to the wall topo when no dedicated route topo exists.

- db.ts v19: wall_topos_cache, wall_topo_lines_cache, route_topos_cache
- src/features/topos/: schema, service, queries, README
- TopoViewer molecule: SVG overlay with fat hit targets, vector-effect
  non-scaling-stroke, selectable wall lines + bottom route list panel
- TopoModal molecule: fixed full-screen with pinch-to-zoom (1–4×) and
  double-tap reset
- TopoBuilder organism: DrawingCanvas with tap-add, handle-drag and
  midpoint-handle-insert; WallTopoBuilder + RouteTopoBuilder variants
- WallView: topo thumbnail + admin builder + modal
- RouteDetailView: route topo + wall-topo fallback + admin builder

https://claude.ai/code/session_01KuFzXEXbPfoyaraSBz6p26