### PR TITLE
feat: add feel rating to burns with FeelSlider, closes #93

### DIFF
--- a/src/components/README.md
+++ b/src/components/README.md
@@ -27,6 +27,7 @@ templates   Layout shells with no real data — just children/slots.
 | `Select` | Dropdown select |
 | `Spinner` | Loading indicator |
 | `ToggleGroup` | Full-width segmented button toggle (e.g. todo/project/sent) |
+| `FeelSlider` | Horizontal segmented slider with 6 circular radio steps (0–5) and a dynamic label above the selected step. Tapping the active step deselects it (nullable). Used in burn add/edit forms. Props: `value: number \| null \| undefined`, `onChange(value: number \| null)`. |
 
 ### Molecules
 | Component | Purpose |

--- a/src/components/atoms/FeelSlider.tsx
+++ b/src/components/atoms/FeelSlider.tsx
@@ -1,0 +1,57 @@
+import { cn } from "@/lib/cn";
+
+const FEEL_LABELS: Record<number, string> = {
+	0: "Impossible",
+	1: "Very far",
+	2: "Far",
+	3: "Getting closer",
+	4: "Close",
+	5: "It will go",
+};
+
+interface FeelSliderProps {
+	value: number | null | undefined;
+	onChange: (value: number | null) => void;
+}
+
+export const FeelSlider = ({ value, onChange }: FeelSliderProps) => {
+	return (
+		<div className="w-full px-1 pt-6 pb-2">
+			<div className="relative flex items-center justify-between">
+				{/* connecting line */}
+				<div className="absolute inset-x-0 top-1/2 -translate-y-1/2 h-px bg-border-default" />
+
+				{[0, 1, 2, 3, 4, 5].map((step) => {
+					const selected = value === step;
+					return (
+						<div key={step} className="relative flex flex-col items-center">
+							{/* label above selected */}
+							<span
+								className={cn(
+									"absolute bottom-full mb-2 text-xs whitespace-nowrap transition-opacity",
+									selected
+										? "text-accent-primary opacity-100"
+										: "opacity-0 pointer-events-none",
+								)}
+							>
+								{FEEL_LABELS[step]}
+							</span>
+
+							<button
+								type="button"
+								aria-label={FEEL_LABELS[step]}
+								onClick={() => onChange(selected ? null : step)}
+								className={cn(
+									"relative z-10 w-6 h-6 rounded-full border-2 transition-colors",
+									selected
+										? "bg-accent-primary border-accent-primary"
+										: "bg-surface-card border-border-default",
+								)}
+							/>
+						</div>
+					);
+				})}
+			</div>
+		</div>
+	);
+};

--- a/src/features/burns/README.md
+++ b/src/features/burns/README.md
@@ -8,12 +8,20 @@ Per-user timestamped notes on a climb representing a single attempt or session. 
 
 | Schema | Purpose |
 |---|---|
-| `BurnSchema` | Full DB record: `id, climb_id, user_id, date, outcome, notes, created_at, updated_at, deleted_at` |
-| `BurnFormSchema` | Form input: `date, notes` |
+| `BurnSchema` | Full DB record: `id, climb_id, user_id, date, outcome, notes, feel, created_at, updated_at, deleted_at` |
+| `BurnFormSchema` | Form input: `date, notes, feel` |
 
 Types: `Burn`, `BurnFormValues`
 
 The `outcome` column exists in the DB but defaults to `'attempt'` and is not exposed in the UI.
+
+The `feel` column is an optional integer 0–5 rating of how close the climber felt to sending:
+- 0: Impossible
+- 1: Very far
+- 2: Far
+- 3: Getting closer
+- 4: Close
+- 5: It will go
 
 ---
 
@@ -23,7 +31,7 @@ The `outcome` column exists in the DB but defaults to `'attempt'` and is not exp
 |---|---|
 | `fetchBurns(climbId)` | All non-deleted burns for a climb, sorted date DESC |
 | `insertBurn(climbId, userId, data)` | Insert with `crypto.randomUUID()`, outcome defaults to `'attempt'` |
-| `updateBurn(id, data)` | Update date and notes |
+| `updateBurn(id, data)` | Update date, notes, and feel |
 | `softDeleteBurn(id)` | Set `deleted_at` |
 | `applyRemoteBurn(burn)` | `INSERT OR REPLACE` preserving server timestamps |
 

--- a/src/features/burns/burns.schema.ts
+++ b/src/features/burns/burns.schema.ts
@@ -7,6 +7,7 @@ export const BurnSchema = z.object({
 	date: z.string(),
 	outcome: z.string(),
 	notes: z.string().nullable().optional(),
+	feel: z.number().int().min(0).max(5).nullable().optional(),
 	created_at: z.string(),
 	updated_at: z.string(),
 	deleted_at: z.string().nullable().optional(),
@@ -17,6 +18,7 @@ export type Burn = z.infer<typeof BurnSchema>;
 export const BurnFormSchema = z.object({
 	date: z.string().min(1, "Date is required"),
 	notes: z.string().optional(),
+	feel: z.number().int().min(0).max(5).nullable().optional(),
 });
 
 export type BurnFormValues = z.infer<typeof BurnFormSchema>;

--- a/src/features/burns/burns.service.ts
+++ b/src/features/burns/burns.service.ts
@@ -17,9 +17,9 @@ export async function insertBurn(
 	const db = await getDb();
 	const id = crypto.randomUUID();
 	await db.execute(
-		`INSERT INTO burns (id, climb_id, user_id, date, outcome, notes)
-     VALUES (?, ?, ?, ?, 'attempt', ?)`,
-		[id, climbId, userId, data.date, data.notes ?? null],
+		`INSERT INTO burns (id, climb_id, user_id, date, outcome, notes, feel)
+     VALUES (?, ?, ?, ?, 'attempt', ?, ?)`,
+		[id, climbId, userId, data.date, data.notes ?? null, data.feel ?? null],
 	);
 }
 
@@ -29,9 +29,9 @@ export async function updateBurn(
 ): Promise<void> {
 	const db = await getDb();
 	await db.execute(
-		`UPDATE burns SET date = ?, notes = ?
+		`UPDATE burns SET date = ?, notes = ?, feel = ?
      WHERE id = ? AND deleted_at IS NULL`,
-		[data.date, data.notes ?? null, id],
+		[data.date, data.notes ?? null, data.feel ?? null, id],
 	);
 }
 
@@ -47,9 +47,9 @@ export async function applyRemoteBurn(burn: Burn): Promise<void> {
 	const db = await getDb();
 	await db.execute(
 		`INSERT OR REPLACE INTO burns
-     (id, climb_id, user_id, date, outcome, notes,
+     (id, climb_id, user_id, date, outcome, notes, feel,
       created_at, updated_at, deleted_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		[
 			burn.id,
 			burn.climb_id,
@@ -57,6 +57,7 @@ export async function applyRemoteBurn(burn: Burn): Promise<void> {
 			burn.date,
 			burn.outcome,
 			burn.notes ?? null,
+			burn.feel ?? null,
 			burn.created_at,
 			burn.updated_at,
 			burn.deleted_at ?? null,

--- a/src/features/sync/sync.service.ts
+++ b/src/features/sync/sync.service.ts
@@ -145,9 +145,9 @@ export async function pullBurns(userId: string, since?: string): Promise<void> {
 	for (const row of data) {
 		await db.execute(
 			`INSERT OR REPLACE INTO burns
-       (id, climb_id, user_id, date, outcome, notes,
+       (id, climb_id, user_id, date, outcome, notes, feel,
         created_at, updated_at, deleted_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			[
 				row.id,
 				row.climb_id,
@@ -155,6 +155,7 @@ export async function pullBurns(userId: string, since?: string): Promise<void> {
 				row.date,
 				row.outcome,
 				row.notes ?? null,
+				row.feel ?? null,
 				row.created_at,
 				row.updated_at,
 				row.deleted_at ?? null,

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -475,6 +475,11 @@ const migrations: Migration[] = [
 		await db.execute(`ALTER TABLE crags_cache ADD COLUMN approach TEXT`);
 		await db.execute(`ALTER TABLE walls_cache ADD COLUMN approach TEXT`);
 	},
+
+	// v21: feel rating on burns (#93)
+	async (db) => {
+		await db.execute(`ALTER TABLE burns ADD COLUMN feel INTEGER`);
+	},
 ];
 
 export async function runMigrations(db: DbAdapter): Promise<void> {

--- a/src/views/ClimbDetailView.tsx
+++ b/src/views/ClimbDetailView.tsx
@@ -2,6 +2,7 @@ import { useNavigate, useParams } from "@tanstack/react-router";
 import { ChevronDown, ExternalLink, Pencil, Plus, Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Button } from "@/components/atoms/Button";
+import { FeelSlider } from "@/components/atoms/FeelSlider";
 import { Input } from "@/components/atoms/Input";
 import { Spinner } from "@/components/atoms/Spinner";
 import { ClimbImageGallery } from "@/components/molecules/ClimbImageGallery";
@@ -21,6 +22,15 @@ import { useClimbsStore } from "@/features/climbs/climbs.store";
 import { useRoute } from "@/features/routes/routes.queries";
 import { cn } from "@/lib/cn";
 import { buildLocationString } from "@/utils/build-location-string";
+
+const FEEL_LABELS: Record<number, string> = {
+	0: "Impossible",
+	1: "Very far",
+	2: "Far",
+	3: "Getting closer",
+	4: "Close",
+	5: "It will go",
+};
 
 const ClimbDetailView = () => {
 	const { climbId } = useParams({ from: "/climbs/$climbId" });
@@ -42,9 +52,11 @@ const ClimbDetailView = () => {
 		new Date().toISOString().slice(0, 10),
 	);
 	const [addNotes, setAddNotes] = useState("");
+	const [addFeel, setAddFeel] = useState<number | null>(null);
 	const [editingBurnId, setEditingBurnId] = useState<string | null>(null);
 	const [editDate, setEditDate] = useState("");
 	const [editNotes, setEditNotes] = useState("");
+	const [editFeel, setEditFeel] = useState<number | null>(null);
 
 	useEffect(() => {
 		setSelectedClimbId(climbId);
@@ -235,6 +247,7 @@ const ClimbDetailView = () => {
 									value={addNotes}
 									onChange={(e) => setAddNotes(e.target.value)}
 								/>
+								<FeelSlider value={addFeel} onChange={setAddFeel} />
 								<Button
 									size="small"
 									disabled={!addDate || addBurn.isPending}
@@ -245,6 +258,7 @@ const ClimbDetailView = () => {
 												data: {
 													date: addDate,
 													notes: addNotes || undefined,
+													feel: addFeel,
 												},
 											},
 											{
@@ -252,6 +266,7 @@ const ClimbDetailView = () => {
 													setShowAddBurn(false);
 													setAddDate(new Date().toISOString().slice(0, 10));
 													setAddNotes("");
+													setAddFeel(null);
 												},
 											},
 										);
@@ -281,6 +296,7 @@ const ClimbDetailView = () => {
 													value={editNotes}
 													onChange={(e) => setEditNotes(e.target.value)}
 												/>
+												<FeelSlider value={editFeel} onChange={setEditFeel} />
 												<div className="flex gap-2">
 													<Button
 														size="small"
@@ -292,6 +308,7 @@ const ClimbDetailView = () => {
 																	data: {
 																		date: editDate,
 																		notes: editNotes || undefined,
+																		feel: editFeel,
 																	},
 																},
 																{
@@ -315,6 +332,11 @@ const ClimbDetailView = () => {
 											<div className="flex items-center justify-between">
 												<div>
 													<p className="text-sm font-semibold">{burn.date}</p>
+													{burn.feel != null && (
+														<p className="text-xs text-accent-primary">
+															{FEEL_LABELS[burn.feel]}
+														</p>
+													)}
 													{burn.notes && (
 														<p className="text-sm text-text-secondary">
 															{burn.notes}
@@ -329,6 +351,7 @@ const ClimbDetailView = () => {
 															setEditingBurnId(burn.id);
 															setEditDate(burn.date);
 															setEditNotes(burn.notes ?? "");
+															setEditFeel(burn.feel ?? null);
 														}}
 													>
 														<Pencil size={16} />


### PR DESCRIPTION
Adds an optional 0–5 proximity-to-send rating to burn sessions.
- DB migration v21: ALTER TABLE burns ADD COLUMN feel INTEGER
- BurnSchema + BurnFormSchema: optional feel field (int 0–5 nullable)
- insertBurn / updateBurn / applyRemoteBurn + pullBurns: propagate feel
- FeelSlider atom: horizontal line, 6 circular radio steps, dynamic label above selected; tap active step to deselect
- ClimbDetailView: FeelSlider in add + edit burn forms; feel label shown in burn list view

https://claude.ai/code/session_01XB9J7uyR62C4btAs1muc9Q