### PR TITLE
feat: fix personal pin count badge and replace popup with modal, closes #94

### DIFF
--- a/src/features/map/README.md
+++ b/src/features/map/README.md
@@ -10,6 +10,7 @@ Map-specific data queries for the Personal mode in MapView. Discovery mode uses 
 |---|---|
 | `fetchPersonalCrags(userId)` | Crags with lat/lng where the user has climbs. Returns route count, climb count, and per-status counts (sent, project, todo). |
 | `fetchPersonalWalls(userId)` | Walls with lat/lng where the user has climbs. Returns route count and per-status counts. |
+| `fetchClimbsAtPin(userId, pinType, pinId)` | Climbs logged at a specific crag or wall pin. Returns id, name, grade, sent_status for modal display. |
 
 ### Types
 
@@ -17,14 +18,16 @@ Map-specific data queries for the Personal mode in MapView. Discovery mode uses 
 |---|---|
 | `PersonalCrag` | id, name, lat, lng, approach, route_count, climb_count, sent_count, project_count, todo_count, has_sent, has_project, has_todo |
 | `PersonalWall` | id, crag_id, name, crag_name, lat, lng, approach, route_count, sent_count, project_count, todo_count |
+| `PinClimb` | id, name, grade, sent_status |
 
 ---
 
 ## map.queries.ts
 
 ```ts
-usePersonalCrags()   // crags with user's climbs + coordinates
-usePersonalWalls()   // walls with user's climbs + coordinates
+usePersonalCrags()                        // crags with user's climbs + coordinates
+usePersonalWalls()                        // walls with user's climbs + coordinates
+useClimbsAtPin(pinType, pinId)            // climbs at a specific crag/wall pin (for modal)
 ```
 
-Both are enabled only when a user is logged in.
+All are enabled only when a user is logged in.

--- a/src/features/map/map.queries.ts
+++ b/src/features/map/map.queries.ts
@@ -1,6 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import { useAuthStore } from "@/features/auth/auth.store";
-import { fetchPersonalCrags, fetchPersonalWalls } from "./map.service";
+import {
+	fetchClimbsAtPin,
+	fetchPersonalCrags,
+	fetchPersonalWalls,
+} from "./map.service";
 
 export function usePersonalCrags() {
 	const userId = useAuthStore((s) => s.user?.id ?? "");
@@ -17,5 +21,17 @@ export function usePersonalWalls() {
 		queryKey: ["personal_walls", userId],
 		queryFn: () => fetchPersonalWalls(userId),
 		enabled: !!userId,
+	});
+}
+
+export function useClimbsAtPin(
+	pinType: "crag" | "wall" | null,
+	pinId: string | null,
+) {
+	const userId = useAuthStore((s) => s.user?.id ?? "");
+	return useQuery({
+		queryKey: ["pin_climbs", userId, pinType, pinId],
+		queryFn: () => fetchClimbsAtPin(userId, pinType!, pinId!),
+		enabled: !!userId && !!pinType && !!pinId,
 	});
 }

--- a/src/features/map/map.service.ts
+++ b/src/features/map/map.service.ts
@@ -89,6 +89,44 @@ export type PersonalWall = {
 	todo_count: number;
 };
 
+export type PinClimb = {
+	id: string;
+	name: string;
+	grade: string;
+	sent_status: string;
+};
+
+export async function fetchClimbsAtPin(
+	userId: string,
+	pinType: "crag" | "wall",
+	pinId: string,
+): Promise<PinClimb[]> {
+	const db = await getDb();
+	if (pinType === "crag") {
+		return db.select<PinClimb[]>(
+			`SELECT cl.id, cl.name, cl.grade, cl.sent_status
+			 FROM climbs cl
+			 JOIN routes_cache r ON r.id = cl.route_id
+			 JOIN walls_cache w ON w.id = r.wall_id
+			 WHERE w.crag_id = ?
+			   AND cl.user_id = ?
+			   AND cl.deleted_at IS NULL
+			 ORDER BY cl.name COLLATE NOCASE ASC`,
+			[pinId, userId],
+		);
+	}
+	return db.select<PinClimb[]>(
+		`SELECT cl.id, cl.name, cl.grade, cl.sent_status
+		 FROM climbs cl
+		 JOIN routes_cache r ON r.id = cl.route_id
+		 WHERE r.wall_id = ?
+		   AND cl.user_id = ?
+		   AND cl.deleted_at IS NULL
+		 ORDER BY cl.name COLLATE NOCASE ASC`,
+		[pinId, userId],
+	);
+}
+
 export async function fetchPersonalWalls(
 	userId: string,
 ): Promise<PersonalWall[]> {

--- a/src/views/MapView.tsx
+++ b/src/views/MapView.tsx
@@ -5,7 +5,7 @@ import {
 	requestPermissions,
 } from "@tauri-apps/plugin-geolocation";
 import L from "leaflet";
-import { Crosshair, Layers, MapPin, Minus, Plus } from "lucide-react";
+import { Crosshair, Layers, MapPin, Minus, Plus, X } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 import {
 	MapContainer,
@@ -20,7 +20,12 @@ import {
 	useAllCragsWithCoords,
 	useAllWallsWithCoords,
 } from "@/features/locations/locations.queries";
-import { usePersonalCrags, usePersonalWalls } from "@/features/map/map.queries";
+import {
+	useClimbsAtPin,
+	usePersonalCrags,
+	usePersonalWalls,
+} from "@/features/map/map.queries";
+import { cn } from "@/lib/cn";
 import { tileLayers } from "@/lib/map-tiles";
 import { useUiStore } from "@/stores/ui.store";
 
@@ -239,6 +244,112 @@ const FilterCheck = ({
 	</label>
 );
 
+// ── Personal pin modal ───────────────────────────────────────────────────────
+
+const SENT_STATUSES = new Set(["sent", "flash", "redpoint", "onsight"]);
+
+type SelectedPin = { type: "crag" | "wall"; id: string; name: string };
+
+const PersonalPinModal = ({
+	pin,
+	showSent,
+	showProject,
+	showTodo,
+	onClose,
+}: {
+	pin: SelectedPin;
+	showSent: boolean;
+	showProject: boolean;
+	showTodo: boolean;
+	onClose: () => void;
+}) => {
+	const navigate = useNavigate();
+	const { data: climbs = [], isLoading } = useClimbsAtPin(pin.type, pin.id);
+
+	const filtered = climbs.filter((c) => {
+		if (showSent && SENT_STATUSES.has(c.sent_status)) return true;
+		if (showProject && c.sent_status === "project") return true;
+		if (showTodo && c.sent_status === "todo") return true;
+		return false;
+	});
+
+	return (
+		<div
+			className="fixed inset-0 z-[2000] flex flex-col justify-end"
+			onClick={onClose}
+		>
+			<div
+				className="bg-surface-card rounded-t-[var(--radius-lg)] max-h-[60dvh] flex flex-col shadow-xl"
+				onClick={(e) => e.stopPropagation()}
+			>
+				{/* Header */}
+				<div className="flex items-center justify-between px-4 py-3 border-b border-border-default shrink-0">
+					<span className="font-semibold text-text-primary truncate">
+						{pin.name}
+					</span>
+					<button type="button" onClick={onClose} className="ml-2 shrink-0">
+						<X size={18} className="text-text-secondary" />
+					</button>
+				</div>
+
+				{/* List */}
+				<div className="overflow-y-auto flex-1 px-4 py-1">
+					{isLoading && (
+						<div className="flex justify-center py-4">
+							<Spinner />
+						</div>
+					)}
+					{!isLoading && filtered.length === 0 && (
+						<p className="text-sm text-text-secondary py-4 text-center">
+							No climbs match the active filters.
+						</p>
+					)}
+					{!isLoading &&
+						filtered.map((climb) => (
+							<button
+								key={climb.id}
+								type="button"
+								className="flex items-center justify-between w-full py-3 border-b border-border-default last:border-0 gap-3"
+								onClick={() => {
+									onClose();
+									navigate({
+										to: "/climbs/$climbId",
+										params: { climbId: climb.id },
+									});
+								}}
+							>
+								<span className="text-sm font-medium text-text-primary truncate text-left">
+									{climb.name}
+								</span>
+								<div className="flex items-center gap-2 shrink-0">
+									<span className="text-xs text-text-secondary">
+										{climb.grade}
+									</span>
+									<span
+										className={cn(
+											"text-xs px-1.5 py-0.5 rounded-full font-medium",
+											SENT_STATUSES.has(climb.sent_status) &&
+												"bg-accent-success/20 text-accent-success",
+											climb.sent_status === "project" &&
+												"bg-accent-primary/20 text-accent-primary",
+											climb.sent_status === "todo" &&
+												"bg-text-secondary/20 text-text-secondary",
+										)}
+									>
+										{climb.sent_status.charAt(0).toUpperCase() +
+											climb.sent_status.slice(1)}
+									</span>
+								</div>
+							</button>
+						))}
+				</div>
+
+				<div style={{ paddingBottom: "env(safe-area-inset-bottom)" }} />
+			</div>
+		</div>
+	);
+};
+
 // ── MapView ─────────────────────────────────────────────────────────────────
 
 type Mode = "discovery" | "personal";
@@ -267,6 +378,8 @@ const MapView = () => {
 	const [showProject, setShowProject] = useState(true);
 	const [showTodo, setShowTodo] = useState(true);
 
+	const [selectedPin, setSelectedPin] = useState<SelectedPin | null>(null);
+
 	const { data: allCrags = [], isLoading: loadingDiscovery } =
 		useAllCragsWithCoords();
 	const { data: allWalls = [] } = useAllWallsWithCoords();
@@ -285,6 +398,15 @@ const MapView = () => {
 			(showTrad ? pin.trad_count : 0) +
 			(showBoulder ? pin.boulder_count : 0),
 		[showSport, showTrad, showBoulder],
+	);
+
+	// Personal filtered count: sum only the checked status counts
+	const personalFilteredCount = useCallback(
+		(pin: { sent_count: number; project_count: number; todo_count: number }) =>
+			(showSent ? pin.sent_count : 0) +
+			(showProject ? pin.project_count : 0) +
+			(showTodo ? pin.todo_count : 0),
+		[showSent, showProject, showTodo],
 	);
 
 	// Filter discovery crags/walls by route type.
@@ -558,42 +680,16 @@ const MapView = () => {
 							<Marker
 								key={crag.id}
 								position={[crag.lat, crag.lng]}
-								icon={countIcon(crag.route_count, "#d97706")}
-							>
-								<Popup>
-									<div className="flex flex-col gap-1">
-										<button
-											type="button"
-											className="text-sm font-medium text-accent-secondary"
-											onClick={() =>
-												navigate({
-													to: "/crags/$cragId",
-													params: { cragId: crag.id },
-												})
-											}
-										>
-											<MapPin size={14} className="inline mr-1" />
-											{crag.name}
-										</button>
-										<span className="text-xs text-gray-500">
-											{[
-												crag.sent_count > 0 && `${crag.sent_count} Sent`,
-												crag.project_count > 0 &&
-													`${crag.project_count} Project`,
-												crag.todo_count > 0 && `${crag.todo_count} Todo`,
-											]
-												.filter(Boolean)
-												.join(" · ")}
-										</span>
-										{crag.approach && (
-											<p className="text-xs text-gray-500 max-w-[180px]">
-												{crag.approach}
-											</p>
-										)}
-										<ZoomToButton lat={crag.lat} lng={crag.lng} />
-									</div>
-								</Popup>
-							</Marker>
+								icon={countIcon(personalFilteredCount(crag), "#d97706")}
+								eventHandlers={{
+									click: () =>
+										setSelectedPin({
+											type: "crag",
+											id: crag.id,
+											name: crag.name,
+										}),
+								}}
+							/>
 						))}
 
 					{/* Personal wall pins at high zoom */}
@@ -603,41 +699,16 @@ const MapView = () => {
 							<Marker
 								key={wall.id}
 								position={[wall.lat, wall.lng]}
-								icon={countIcon(wall.route_count, "#eab308")}
-							>
-								<Popup>
-									<div className="flex flex-col gap-0.5">
-										<button
-											type="button"
-											className="text-sm font-medium text-yellow-500"
-											onClick={() =>
-												navigate({
-													to: "/walls/$wallId",
-													params: { wallId: wall.id },
-												})
-											}
-										>
-											<MapPin size={14} className="inline mr-1" />
-											{wall.name}
-										</button>
-										<span className="text-xs text-gray-500">
-											{[
-												wall.sent_count > 0 && `${wall.sent_count} Sent`,
-												wall.project_count > 0 &&
-													`${wall.project_count} Project`,
-												wall.todo_count > 0 && `${wall.todo_count} Todo`,
-											]
-												.filter(Boolean)
-												.join(" · ")}
-										</span>
-										{wall.approach && (
-											<p className="text-xs text-gray-500 max-w-[180px]">
-												{wall.approach}
-											</p>
-										)}
-									</div>
-								</Popup>
-							</Marker>
+								icon={countIcon(personalFilteredCount(wall), "#eab308")}
+								eventHandlers={{
+									click: () =>
+										setSelectedPin({
+											type: "wall",
+											id: wall.id,
+											name: wall.name,
+										}),
+								}}
+							/>
 						))}
 				</MapContainer>
 
@@ -652,6 +723,16 @@ const MapView = () => {
 							</p>
 						</div>
 					)}
+
+				{selectedPin && (
+					<PersonalPinModal
+						pin={selectedPin}
+						showSent={showSent}
+						showProject={showProject}
+						showTodo={showTodo}
+						onClose={() => setSelectedPin(null)}
+					/>
+				)}
 			</div>
 		</div>
 	);


### PR DESCRIPTION
- Count badge on personal crag/wall pins now reflects active filter
  selections (sent/project/todo) instead of total route count
- Tapping a personal pin opens a bottom-sheet modal instead of a
  Leaflet Popup
- Modal lists climbs at that location filtered to active status
  selections, each showing name, grade, and status badge
- Tapping a climb item navigates to ClimbDetailView
- Add fetchClimbsAtPin service function and useClimbsAtPin query hook

https://claude.ai/code/session_01U5voMM17eHbcxZV3bxXBAs