### PR TITLE
feat: add sent date field to climb form, closes #100

### DIFF
--- a/src/components/organisms/ClimbForm.tsx
+++ b/src/components/organisms/ClimbForm.tsx
@@ -383,6 +383,7 @@ export const ClimbForm = ({
 			wall: defaultValues?.wall ?? "",
 			route_location: defaultValues?.route_location ?? "",
 			link: defaultValues?.link ?? "",
+			sent_date: defaultValues?.sent_date ?? null,
 		},
 		onSubmit: async ({ value }) => {
 			const gradeValue =
@@ -467,10 +468,50 @@ export const ClimbForm = ({
 								{ value: "sent", label: "Sent" },
 							]}
 							value={field.state.value}
-							onChange={(v) => field.handleChange(v as SentStatus)}
+							onChange={(v) => {
+								const newStatus = v as SentStatus;
+								field.handleChange(newStatus);
+								if (newStatus === "sent") {
+									const today = new Date().toISOString().split("T")[0];
+									form.setFieldValue(
+										"sent_date",
+										form.getFieldValue("sent_date") ?? today,
+									);
+								} else {
+									form.setFieldValue("sent_date", null);
+								}
+							}}
 						/>
 					)}
 				</form.Field>
+
+				<form.Subscribe selector={(state) => state.values.sent_status}>
+					{(sentStatus) =>
+						sentStatus === "sent" ? (
+							<form.Field name="sent_date">
+								{(field) => (
+									<div className="flex flex-col gap-1">
+										<label
+											htmlFor="sent_date"
+											className="text-xs text-text-secondary"
+										>
+											Sent date
+										</label>
+										<Input
+											id="sent_date"
+											type="date"
+											value={field.state.value ?? ""}
+											onChange={(e) =>
+												field.handleChange(e.target.value || null)
+											}
+											max={new Date().toISOString().split("T")[0]}
+										/>
+									</div>
+								)}
+							</form.Field>
+						) : null
+					}
+				</form.Subscribe>
 
 				<form.Field name="link">
 					{(field) => (

--- a/src/features/climbs/README.md
+++ b/src/features/climbs/README.md
@@ -31,6 +31,7 @@ ClimbSchema = {
   route_location?: string
   link?: string
   route_id?: string      // optional link to routes_cache
+  sent_date?: string | null  // YYYY-MM-DD; set when sent_status is 'sent'; cleared otherwise
   created_at: string
   updated_at: string
   deleted_at?: string | null
@@ -71,6 +72,7 @@ CREATE TABLE IF NOT EXISTS climbs (
     route_location   TEXT,
     link             TEXT,
     route_id         TEXT,
+    sent_date        TEXT,
     deleted_at       TEXT,
     created_at       TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at       TEXT NOT NULL DEFAULT (datetime('now'))
@@ -183,7 +185,7 @@ public.climbs (
   id uuid pk,  user_id uuid,  name text,  route_type text,
   grade text,  moves text,  sent_status text,
   country text,  area text,  sub_area text,  crag text,  wall text,  route_location text,  link text,
-  route_id uuid references public.routes,
+  route_id uuid references public.routes,  sent_date text,
   created_at timestamptz,  updated_at timestamptz,  deleted_at timestamptz
 )
 -- RLS: auth.uid() = user_id

--- a/src/features/climbs/climbs.schema.ts
+++ b/src/features/climbs/climbs.schema.ts
@@ -85,6 +85,7 @@ export const ClimbSchema = z.object({
 	route_location: z.string().optional(),
 	link: z.string().optional(),
 	route_id: z.string().nullable().optional(),
+	sent_date: z.string().nullable().optional(),
 	created_at: z.string(),
 	updated_at: z.string(),
 	deleted_at: z.string().nullable().optional(),
@@ -105,6 +106,7 @@ export const ClimbFormSchema = z.object({
 	wall: z.string().optional(),
 	route_location: z.string().optional(),
 	link: z.string().optional(),
+	sent_date: z.string().nullable().optional(),
 });
 
 export type ClimbFormValues = z.infer<typeof ClimbFormSchema>;

--- a/src/features/climbs/climbs.service.ts
+++ b/src/features/climbs/climbs.service.ts
@@ -128,8 +128,8 @@ export async function insertClimb(
 	}
 
 	await db.execute(
-		`INSERT INTO climbs (id, user_id, name, route_type, grade, moves, sent_status, country, area, sub_area, crag, wall, route_location, link, route_id)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO climbs (id, user_id, name, route_type, grade, moves, sent_status, country, area, sub_area, crag, wall, route_location, link, route_id, sent_date)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		[
 			id,
 			userId,
@@ -146,6 +146,7 @@ export async function insertClimb(
 			data.route_location ?? null,
 			data.link ?? null,
 			routeId ?? null,
+			data.sent_date ?? null,
 		],
 	);
 }
@@ -159,7 +160,7 @@ export async function updateClimb(
 	await db.execute(
 		`UPDATE climbs
      SET name = ?, route_type = ?, grade = ?, moves = ?, sent_status = ?,
-         country = ?, area = ?, sub_area = ?, crag = ?, wall = ?, route_location = ?, link = ?, route_id = ?
+         country = ?, area = ?, sub_area = ?, crag = ?, wall = ?, route_location = ?, link = ?, route_id = ?, sent_date = ?
      WHERE id = ? AND deleted_at IS NULL`,
 		[
 			data.name,
@@ -175,6 +176,7 @@ export async function updateClimb(
 			data.route_location ?? null,
 			data.link ?? null,
 			routeId ?? null,
+			data.sent_date ?? null,
 			id,
 		],
 	);
@@ -257,8 +259,8 @@ export async function applyRemoteClimb(climb: Climb): Promise<void> {
 		`INSERT OR REPLACE INTO climbs
      (id, user_id, name, route_type, grade, moves, sent_status,
       country, area, sub_area, crag, wall, route_location, link, route_id,
-      created_at, updated_at, deleted_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      sent_date, created_at, updated_at, deleted_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		[
 			climb.id,
 			climb.user_id,
@@ -275,6 +277,7 @@ export async function applyRemoteClimb(climb: Climb): Promise<void> {
 			climb.route_location ?? null,
 			climb.link ?? null,
 			climb.route_id ?? null,
+			climb.sent_date ?? null,
 			climb.created_at,
 			climb.updated_at,
 			climb.deleted_at ?? null,

--- a/src/lib/README.md
+++ b/src/lib/README.md
@@ -69,6 +69,9 @@ Versioned migration runner. Maintains a `schema_version` table (single row) and 
 | v17 | Backfill `server_updated_at` on `downloaded_regions` for devices that skipped v15 |
 | v18 | `crag`, `wall` on `climbs` — full 5-level location breadcrumb (#44) |
 | v19 | `wall_topos_cache`, `wall_topo_lines_cache`, `route_topos_cache` tables for topo photos |
+| v20 | `approach` on `crags_cache` and `walls_cache` (#92) |
+| v21 | `feel` on `burns` (#93) |
+| v22 | `sent_date` on `climbs` — date the climb was sent (#100) |
 
 ### Rules
 - Always use `?` positional parameters — never string interpolation (SQL injection)

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -480,6 +480,11 @@ const migrations: Migration[] = [
 	async (db) => {
 		await db.execute(`ALTER TABLE burns ADD COLUMN feel INTEGER`);
 	},
+
+	// v22: sent_date on climbs (#100)
+	async (db) => {
+		await db.execute(`ALTER TABLE climbs ADD COLUMN sent_date TEXT`);
+	},
 ];
 
 export async function runMigrations(db: DbAdapter): Promise<void> {


### PR DESCRIPTION
- v22 migration: ALTER TABLE climbs ADD COLUMN sent_date TEXT
- Add sent_date to ClimbSchema and ClimbFormSchema (nullable optional string)
- Thread sent_date through insertClimb, updateClimb, and applyRemoteClimb
- Show date input in ClimbForm when status is 'Sent'; defaults to today,
  max is today, clears when status changes away from 'sent'
- Update climbs and lib READMEs with schema and migration history

https://claude.ai/code/session_01358hF9LHoypJmtowGMAN1q