### PR TITLE
fix: stack multiple toasts vertically instead of overlapping, closes …

### DIFF
--- a/src/components/molecules/Toast.tsx
+++ b/src/components/molecules/Toast.tsx
@@ -19,7 +19,7 @@ export const Toast = ({ id, message, type }: ToastType) => {
 	return (
 		<div
 			className={cn(
-				"bg-surface-card text-text-primary border-l-4 shadow-toast rounded-[var(--radius-xl)] border border-card-border absolute top-[2vh] left-[calc(50vw)] -translate-x-1/2 p-2.5 whitespace-nowrap",
+				"bg-surface-card text-text-primary border-l-4 shadow-toast rounded-[var(--radius-xl)] border border-card-border p-2.5 whitespace-nowrap",
 				borderColor[type],
 			)}
 		>

--- a/src/components/templates/AppLayout.tsx
+++ b/src/components/templates/AppLayout.tsx
@@ -18,7 +18,7 @@ export const AppLayout = ({ children }: AppLayoutProps) => {
 	return (
 		<div className="bg-surface-page min-h-screen min-w-screen max-w-screen text-text-primary pt-[env(safe-area-inset-top)]">
 			<div className="relative">
-				<div className="absolute top-0 left-0 right-0 pointer-events-none">
+				<div className="fixed top-[2vh] left-1/2 -translate-x-1/2 z-50 flex flex-col gap-2 pointer-events-none items-center">
 					{toasts.map((toast) => (
 						<Toast key={toast.id} {...toast} />
 					))}


### PR DESCRIPTION
…#101

Move toast positioning from each Toast (absolute, same top) to a single fixed flex-col container in AppLayout. Toasts now stack with a gap, newest at the bottom, each fully visible and dismissable independently.

https://claude.ai/code/session_01358hF9LHoypJmtowGMAN1q