### PR TITLE
fix: allow any real number for ape index, closes #104

### DIFF
--- a/src/views/ProfileView.tsx
+++ b/src/views/ProfileView.tsx
@@ -310,8 +310,8 @@ const AuthenticatedProfile = ({
 					: Number(apeVal)
 				: null;
 
-		if (apeCm !== null && (apeCm <= 0 || !Number.isInteger(apeCm))) {
-			setSaveError("Ape index must be a positive whole number");
+		if (apeCm !== null && !Number.isFinite(apeCm)) {
+			setSaveError("Ape index must be a valid number");
 			return;
 		}
 


### PR DESCRIPTION
Ape index (wingspan − height) can be negative, zero, or a decimal.
Replaced the positive-integer-only guard with a simple isFinite check.

https://claude.ai/code/session_01BE75jXSKBdyPoohSqcDzhH