### PR TITLE
feat: add persistent back button to AppLayout, closes #103

### DIFF
--- a/src/components/README.md
+++ b/src/components/README.md
@@ -64,7 +64,7 @@ templates   Layout shells with no real data — just children/slots.
 ### Templates
 | Component | Purpose |
 |---|---|
-| `AppLayout` | Root layout — safe areas, NavBar, Toast renderer |
+| `AppLayout` | Root layout — safe areas, NavBar, Toast renderer, persistent back button (hidden on `/`) |
 
 ---
 

--- a/src/components/templates/AppLayout.tsx
+++ b/src/components/templates/AppLayout.tsx
@@ -1,9 +1,12 @@
 import type { ReactNode } from "react";
 import { useState } from "react";
+import { useRouter } from "@tanstack/react-router";
+import { ChevronLeft } from "lucide-react";
 import { Toast } from "@/components/molecules/Toast";
 import { Drawer } from "@/components/organisms/Drawer";
 import { NavBar } from "@/components/organisms/NavBar";
 import { useAndroidBackButton } from "@/hooks/useAndroidBackButton";
+import { useCurrentRoute } from "@/hooks/useCurrentRoute";
 import { useUiStore } from "@/stores/ui.store";
 
 interface AppLayoutProps {
@@ -13,7 +16,11 @@ interface AppLayoutProps {
 export const AppLayout = ({ children }: AppLayoutProps) => {
 	const toasts = useUiStore((s) => s.toasts);
 	const [drawerOpen, setDrawerOpen] = useState(false);
+	const currentRoute = useCurrentRoute();
+	const router = useRouter();
 	useAndroidBackButton();
+
+	const showBack = currentRoute !== "/";
 
 	return (
 		<div className="bg-surface-page min-h-screen min-w-screen max-w-screen text-text-primary pt-[env(safe-area-inset-top)]">
@@ -23,7 +30,19 @@ export const AppLayout = ({ children }: AppLayoutProps) => {
 						<Toast key={toast.id} {...toast} />
 					))}
 				</div>
-				<main className="pt-4 px-4 pb-[calc(7vh+1.5rem)]">{children}</main>
+				<main className="pt-4 px-4 pb-[calc(7vh+1.5rem)]">
+					{showBack && (
+						<button
+							type="button"
+							className="flex items-center gap-1 text-text-secondary text-sm mb-3 -ml-1"
+							onClick={() => router.history.back()}
+						>
+							<ChevronLeft size={16} />
+							Back
+						</button>
+					)}
+					{children}
+				</main>
 			</div>
 			<NavBar onMenuOpen={() => setDrawerOpen(true)} />
 			<Drawer isOpen={drawerOpen} onClose={() => setDrawerOpen(false)} />

--- a/src/views/AddEditRouteView.tsx
+++ b/src/views/AddEditRouteView.tsx
@@ -193,14 +193,6 @@ const AddEditRouteView = ({ routeId }: AddEditRouteViewProps) => {
 
 	return (
 		<div className="flex flex-col gap-4">
-			<button
-				type="button"
-				className="text-text-secondary text-sm text-left"
-				onClick={() => router.history.back()}
-			>
-				← Back
-			</button>
-
 			<h1 className="text-lg font-display font-semibold">{title}</h1>
 
 			{/* Location — tappable summary opens full-screen sheet */}

--- a/src/views/AddLocationView.tsx
+++ b/src/views/AddLocationView.tsx
@@ -1,4 +1,3 @@
-import { useRouter } from "@tanstack/react-router";
 import { LocationDrillDown } from "@/components/molecules/LocationDrillDown";
 import { useAuthStore } from "@/features/auth/auth.store";
 
@@ -7,19 +6,10 @@ import { useAuthStore } from "@/features/auth/auth.store";
 const noop = () => {};
 
 const AddLocationView = () => {
-	const router = useRouter();
 	const isAdmin = useAuthStore((s) => s.user?.role === "admin");
 
 	return (
 		<div className="flex flex-col gap-4">
-			<button
-				type="button"
-				className="text-text-secondary text-sm text-left"
-				onClick={() => router.history.back()}
-			>
-				← Back
-			</button>
-
 			<h1 className="text-lg font-display font-semibold">Add Location</h1>
 
 			<div className="rounded-lg bg-surface-card p-4 flex flex-col gap-3">

--- a/src/views/CragView.tsx
+++ b/src/views/CragView.tsx
@@ -231,21 +231,6 @@ const CragView = () => {
 
 	return (
 		<div className="flex flex-col gap-3">
-			<button
-				type="button"
-				className="text-text-secondary text-sm text-left"
-				onClick={() => {
-					if (crag?.sub_region_id) {
-						navigate({
-							to: "/sub-regions/$subRegionId",
-							params: { subRegionId: crag.sub_region_id },
-						});
-					}
-				}}
-			>
-				← Back to area
-			</button>
-
 			{crag && (
 				<>
 					<h1 className="text-xl font-display font-bold">{crag.name}</h1>

--- a/src/views/RegionView.tsx
+++ b/src/views/RegionView.tsx
@@ -72,14 +72,6 @@ const RegionView = () => {
 
 	return (
 		<div className="flex flex-col gap-3">
-			<button
-				type="button"
-				className="text-text-secondary text-sm text-left"
-				onClick={() => navigate({ to: "/routes" })}
-			>
-				← Back to routes
-			</button>
-
 			{isStale && (
 				<div className="flex items-center justify-between rounded-lg bg-amber-900/30 border border-amber-700/40 px-4 py-3 text-sm">
 					<span className="text-amber-300">

--- a/src/views/RouteDetailView.tsx
+++ b/src/views/RouteDetailView.tsx
@@ -111,19 +111,6 @@ const RouteDetailView = () => {
 
 	return (
 		<div className="flex flex-col gap-4">
-			<button
-				type="button"
-				className="text-text-secondary text-sm text-left"
-				onClick={() =>
-					navigate({
-						to: "/walls/$wallId",
-						params: { wallId: route.wall_id },
-					})
-				}
-			>
-				← Back to wall
-			</button>
-
 			<div>
 				<h1 className="text-xl font-display font-bold">{route.name}</h1>
 				<div className="flex items-center gap-2 mt-1">

--- a/src/views/SubRegionView.tsx
+++ b/src/views/SubRegionView.tsx
@@ -145,19 +145,6 @@ const SubRegionView = () => {
 
 	return (
 		<div className="flex flex-col gap-3">
-			<button
-				type="button"
-				className="text-text-secondary text-sm text-left"
-				onClick={() =>
-					navigate({
-						to: "/regions/$regionId",
-						params: { regionId: subRegion.region_id },
-					})
-				}
-			>
-				← Back to region
-			</button>
-
 			<h1 className="text-xl font-display font-bold">{subRegion.name}</h1>
 
 			<EditableDescription

--- a/src/views/SubmitRouteView.tsx
+++ b/src/views/SubmitRouteView.tsx
@@ -61,14 +61,6 @@ const SubmitRouteView = () => {
 
 	return (
 		<div className="flex flex-col gap-4">
-			<button
-				type="button"
-				className="text-text-secondary text-sm text-left"
-				onClick={() => router.history.back()}
-			>
-				← Back
-			</button>
-
 			<div className="rounded-lg bg-surface-card p-4">
 				<p className="font-display font-semibold">Submit a route</p>
 				<p className="text-sm text-text-secondary mt-1">Wall: {wallName}</p>

--- a/src/views/WallView.tsx
+++ b/src/views/WallView.tsx
@@ -98,19 +98,6 @@ const WallView = () => {
 
 	return (
 		<div className="flex flex-col gap-3">
-			<button
-				type="button"
-				className="text-text-secondary text-sm text-left"
-				onClick={() =>
-					navigate({
-						to: "/crags/$cragId",
-						params: { cragId: wall.crag_id },
-					})
-				}
-			>
-				← Back to crag
-			</button>
-
 			<h1 className="text-xl font-display font-bold">{wall.name}</h1>
 
 			{isAdmin ? (

--- a/src/views/admin/VerificationView.tsx
+++ b/src/views/admin/VerificationView.tsx
@@ -1,4 +1,3 @@
-import { useRouter } from "@tanstack/react-router";
 import { useState } from "react";
 import { Button } from "@/components/atoms/Button";
 import { Input } from "@/components/atoms/Input";
@@ -478,7 +477,6 @@ const LocationRow = ({
 // ── Main view ─────────────────────────────────────────────────────────────────
 
 const VerificationView = () => {
-	const router = useRouter();
 	const addToast = useUiStore((s) => s.addToast);
 
 	const { data: routes = [], isLoading: routesLoading } = useUnverifiedRoutes();
@@ -519,14 +517,6 @@ const VerificationView = () => {
 
 	return (
 		<div className="flex flex-col gap-4">
-			<button
-				type="button"
-				className="text-text-secondary text-sm text-left"
-				onClick={() => router.history.back()}
-			>
-				← Back
-			</button>
-
 			<h1 className="text-lg font-display font-semibold">Verification</h1>
 
 			{isLoading && <p className="text-text-secondary text-sm">Loading…</p>}


### PR DESCRIPTION
Adds a single back button (ChevronLeft + "Back") to AppLayout that
appears on all views except HomeView ("/"). Removes the per-view back
buttons from AddEditRouteView, AddLocationView, CragView, RegionView,
RouteDetailView, SubRegionView, SubmitRouteView, WallView, and
VerificationView.

https://claude.ai/code/session_015pWMwuCZi5HLKg8sizrhRg