### PR TITLE
feat: replace personal map Popup with modal; close on back button, closes #116

### DIFF
--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -48,9 +48,12 @@ useAndroidBackButton()
 
 **What it does:**
 - Registers `onBackButtonPress` from `@tauri-apps/api/app`
+- If `backHandlerOverride` is set in `ui.store` (e.g. a modal is open): calls that instead of navigating — the modal is responsible for setting and clearing the override
 - If `router.history.length > 1`: calls `router.history.back()`
 - At root: does nothing — the OS closes the app naturally
 - Cleans up via `listener.unregister()` on unmount
+
+**Override pattern:** Components that render an overlay (modal, bottom sheet) can intercept the back button by calling `useUiStore.setBackHandlerOverride(fn)` on mount and `setBackHandlerOverride(null)` on unmount. The `useBackHandlerOverride(fn)` helper inside `MapView.tsx` demonstrates this pattern.
 
 ---
 

--- a/src/hooks/useAndroidBackButton.ts
+++ b/src/hooks/useAndroidBackButton.ts
@@ -1,9 +1,12 @@
 import { useRouter } from "@tanstack/react-router";
 import { onBackButtonPress } from "@tauri-apps/api/app";
 import { useEffect } from "react";
+import { useUiStore } from "@/stores/ui.store";
 
 /**
  * Intercepts the Android hardware back button.
+ * - If a `backHandlerOverride` is set in the UI store (e.g. a modal is open),
+ *   calls that instead of navigating back.
  * - Navigates back if there is history.
  * - Does nothing at the root so the OS can close the app naturally.
  *
@@ -11,9 +14,14 @@ import { useEffect } from "react";
  */
 export function useAndroidBackButton() {
 	const router = useRouter();
+	const backHandlerOverride = useUiStore((s) => s.backHandlerOverride);
 
 	useEffect(() => {
 		const unlistenPromise = onBackButtonPress(() => {
+			if (backHandlerOverride) {
+				backHandlerOverride();
+				return;
+			}
 			if (router.history.length > 1) {
 				router.history.back();
 			}
@@ -23,5 +31,5 @@ export function useAndroidBackButton() {
 		return () => {
 			unlistenPromise.then((listener) => listener.unregister());
 		};
-	}, [router]);
+	}, [router, backHandlerOverride]);
 }

--- a/src/stores/ui.store.ts
+++ b/src/stores/ui.store.ts
@@ -18,6 +18,9 @@ interface UiStore {
 	removeToast: (id: string) => void;
 	userLocation: UserLocation | null;
 	setUserLocation: (loc: UserLocation) => void;
+	/** When set, the Android back button calls this instead of navigating back. */
+	backHandlerOverride: (() => void) | null;
+	setBackHandlerOverride: (fn: (() => void) | null) => void;
 }
 
 const storedTheme =
@@ -59,4 +62,6 @@ export const useUiStore = create<UiStore>((set) => ({
 		localStorage.setItem("betaapp-user-location", JSON.stringify(loc));
 		set({ userLocation: loc });
 	},
+	backHandlerOverride: null,
+	setBackHandlerOverride: (fn) => set({ backHandlerOverride: fn }),
 }));

--- a/src/views/MapView.tsx
+++ b/src/views/MapView.tsx
@@ -6,7 +6,7 @@ import {
 } from "@tauri-apps/plugin-geolocation";
 import L from "leaflet";
 import { Crosshair, Layers, MapPin, Minus, Plus, X } from "lucide-react";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
 	MapContainer,
 	Marker,
@@ -28,6 +28,16 @@ import {
 import { cn } from "@/lib/cn";
 import { tileLayers } from "@/lib/map-tiles";
 import { useUiStore } from "@/stores/ui.store";
+
+// ── Back-button override hook ────────────────────────────────────────────────
+
+function useBackHandlerOverride(handler: (() => void) | null) {
+	const setBackHandlerOverride = useUiStore((s) => s.setBackHandlerOverride);
+	useEffect(() => {
+		setBackHandlerOverride(handler);
+		return () => setBackHandlerOverride(null);
+	}, [handler, setBackHandlerOverride]);
+}
 
 // ── Marker icon with route count ────────────────────────────────────────────
 
@@ -265,6 +275,7 @@ const PersonalPinModal = ({
 }) => {
 	const navigate = useNavigate();
 	const { data: climbs = [], isLoading } = useClimbsAtPin(pin.type, pin.id);
+	useBackHandlerOverride(onClose);
 
 	const filtered = climbs.filter((c) => {
 		if (showSent && SENT_STATUSES.has(c.sent_status)) return true;


### PR DESCRIPTION
- Personal crag/wall pins already used eventHandlers.click to open PersonalPinModal (no Popup); confirmed no Popup on personal pins
- Add backHandlerOverride to ui.store so any overlay can intercept the Android back button
- Update useAndroidBackButton to call the override when set, preventing navigation while a modal is open
- Add useBackHandlerOverride helper in MapView.tsx; wire into PersonalPinModal so back button closes it
- Update src/hooks/README.md to document the override pattern

https://claude.ai/code/session_01Ax2zcbyvAc1yTTPZa5oX9Y