### PR TITLE
feat: admin drag-and-drop route reorder on wall view, closes #148

### DIFF
--- a/src/features/routes/README.md
+++ b/src/features/routes/README.md
@@ -18,6 +18,7 @@ RouteSchema = {
   status: 'pending' | 'verified' | 'rejected'
   created_by: string   // Supabase user UUID
   created_at: string
+  sort_order: number   // admin-defined display order; default 0
 }
 
 // Admin-only type — not stored in SQLite
@@ -76,7 +77,8 @@ CREATE TABLE IF NOT EXISTS routes_cache (
     description TEXT,
     status      TEXT NOT NULL DEFAULT 'verified',
     created_by  TEXT NOT NULL,
-    created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+    created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    sort_order  INTEGER NOT NULL DEFAULT 0   -- v23; admin-defined display order
 );
 ```
 
@@ -91,7 +93,8 @@ Only populated when the user downloads a region (see [`locations/README.md`](../
 | Function | What it does |
 |---|---|
 | `fetchRoute(id)` | Reads a single route from `routes_cache` by id; returns `null` if not found |
-| `fetchRoutes(wallId)` | Reads `routes_cache` for a wall, ordered by name |
+| `fetchRoutes(wallId)` | Reads `routes_cache` for a wall, ordered by `sort_order ASC, name ASC` |
+| `reorderRoutes(orderedIds)` | Admin — updates `sort_order` for each route id in Supabase + local cache |
 | `addRoute(values, userId, isAdmin)` | Inserts into Supabase `routes` + local `routes_cache`; returns the new route `id` |
 | `searchVerifiedRoutes(query)` | Full-text search against Supabase `routes` (verified only, limit 10) |
 | `searchLocalRoutes(query)` | LIKE search on local `routes_cache` by name or grade (verified only, limit 30) |
@@ -143,6 +146,7 @@ useRouteBodyStats(routeId) // body dimension vs grade scatter data from Supabase
 useRouteLinks(routeId)     // non-deleted links for a route from local cache
 useAddRouteLink(routeId)   // mutation — { url, title?, userId }
 useDeleteRouteLink(routeId) // mutation — id
+useReorderRoutes(wallId)   // admin mutation — orderedIds: string[]; invalidates routes for wall
 ```
 
 ---

--- a/src/features/routes/routes.queries.ts
+++ b/src/features/routes/routes.queries.ts
@@ -15,6 +15,7 @@ import {
 	fetchUnverifiedRoutes,
 	mergeRoute,
 	rejectRoute,
+	reorderRoutes,
 	searchLocalRoutes,
 	updateRouteDescription,
 	updateRouteFields,
@@ -123,6 +124,16 @@ export function useAdminDeleteRoute() {
 		onSuccess: (_data, { wallId }) => {
 			qc.invalidateQueries({ queryKey: ["routes", wallId] });
 			qc.invalidateQueries({ queryKey: ["all_routes"] });
+		},
+	});
+}
+
+export function useReorderRoutes(wallId: string) {
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: (orderedIds: string[]) => reorderRoutes(orderedIds),
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: ["routes", wallId] });
 		},
 	});
 }

--- a/src/features/routes/routes.schema.ts
+++ b/src/features/routes/routes.schema.ts
@@ -13,6 +13,7 @@ export const RouteSchema = z.object({
 	status: SubmissionStatus,
 	created_by: z.string(),
 	created_at: z.string(),
+	sort_order: z.number().int().default(0),
 });
 
 export const RouteSubmitSchema = z.object({

--- a/src/features/routes/routes.service.ts
+++ b/src/features/routes/routes.service.ts
@@ -10,9 +10,25 @@ import type {
 export async function fetchRoutes(wallId: string): Promise<Route[]> {
 	const db = await getDb();
 	return db.select<Route[]>(
-		"SELECT * FROM routes_cache WHERE wall_id = ? ORDER BY name ASC",
+		"SELECT * FROM routes_cache WHERE wall_id = ? ORDER BY sort_order ASC, name ASC",
 		[wallId],
 	);
+}
+
+export async function reorderRoutes(orderedIds: string[]): Promise<void> {
+	const db = await getDb();
+	for (let i = 0; i < orderedIds.length; i++) {
+		// biome-ignore lint/suspicious/noExplicitAny: sort_order not yet in generated types
+		const { error } = await (supabase as any)
+			.from("routes")
+			.update({ sort_order: i })
+			.eq("id", orderedIds[i]);
+		if (error) throw error;
+		await db.execute("UPDATE routes_cache SET sort_order = ? WHERE id = ?", [
+			i,
+			orderedIds[i],
+		]);
+	}
 }
 
 export async function fetchRoute(id: string): Promise<Route | null> {

--- a/src/lib/README.md
+++ b/src/lib/README.md
@@ -72,6 +72,7 @@ Versioned migration runner. Maintains a `schema_version` table (single row) and 
 | v20 | `approach` on `crags_cache` and `walls_cache` (#92) |
 | v21 | `feel` on `burns` (#93) |
 | v22 | `sent_date` on `climbs` — date the climb was sent (#100) |
+| v23 | `sort_order` on `routes_cache` — admin-defined display order (#148) |
 
 ### Rules
 - Always use `?` positional parameters — never string interpolation (SQL injection)

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -485,6 +485,13 @@ const migrations: Migration[] = [
 	async (db) => {
 		await db.execute(`ALTER TABLE climbs ADD COLUMN sent_date TEXT`);
 	},
+
+	// v23: sort_order on routes_cache (#148)
+	async (db) => {
+		await db.execute(
+			`ALTER TABLE routes_cache ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0`,
+		);
+	},
 ];
 
 export async function runMigrations(db: DbAdapter): Promise<void> {

--- a/src/views/WallView.tsx
+++ b/src/views/WallView.tsx
@@ -1,5 +1,21 @@
+import type { DragEndEvent } from "@dnd-kit/core";
+import {
+	closestCenter,
+	DndContext,
+	PointerSensor,
+	TouchSensor,
+	useSensor,
+	useSensors,
+} from "@dnd-kit/core";
+import {
+	arrayMove,
+	SortableContext,
+	useSortable,
+	verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { useNavigate, useParams } from "@tanstack/react-router";
-import { MapPin } from "lucide-react";
+import { GripVertical, MapPin } from "lucide-react";
 import { useMemo, useState } from "react";
 import { Button } from "@/components/atoms/Button";
 import { Spinner } from "@/components/atoms/Spinner";
@@ -27,8 +43,54 @@ import {
 	useDeleteWallImage,
 	useWallImages,
 } from "@/features/route-images/route-images.queries";
-import { useRoutes } from "@/features/routes/routes.queries";
+import { useReorderRoutes, useRoutes } from "@/features/routes/routes.queries";
+import type { Route } from "@/features/routes/routes.schema";
 import { useWallTopo, useWallTopoLines } from "@/features/topos/topos.queries";
+
+// ── Sortable route card (reorder mode) ────────────────────────────────────────
+
+const SortableRouteCard = ({ route }: { route: Route }) => {
+	const {
+		attributes,
+		listeners,
+		setNodeRef,
+		transform,
+		transition,
+		isDragging,
+	} = useSortable({ id: route.id });
+
+	const style: React.CSSProperties = {
+		transform: CSS.Transform.toString(transform),
+		transition,
+		opacity: isDragging ? 0.4 : 1,
+		touchAction: "none",
+	};
+
+	return (
+		<div
+			ref={setNodeRef}
+			style={style}
+			className="rounded-lg bg-surface-card p-4 flex items-center gap-3"
+		>
+			<button
+				type="button"
+				className="shrink-0 text-text-tertiary touch-none cursor-grab active:cursor-grabbing"
+				aria-label="Drag to reorder"
+				{...attributes}
+				{...listeners}
+			>
+				<GripVertical size={18} />
+			</button>
+			<div className="flex-1 flex items-center justify-between gap-2">
+				<span className="font-medium">{route.name}</span>
+				<div className="flex items-center gap-2">
+					<span className="text-xs text-text-secondary">{route.grade}</span>
+					<span className="text-xs text-text-tertiary">{route.route_type}</span>
+				</div>
+			</div>
+		</div>
+	);
+};
 
 const ViewOnMap = ({ lat, lng }: { lat: number; lng: number }) => {
 	const navigate = useNavigate();
@@ -68,6 +130,38 @@ const WallView = () => {
 	const [showTopoModal, setShowTopoModal] = useState(false);
 	const [showTopoEdit, setShowTopoEdit] = useState(false);
 	const [dataModalRouteId, setDataModalRouteId] = useState<string | null>(null);
+	const [isReordering, setIsReordering] = useState(false);
+	const [reorderList, setReorderList] = useState<Route[]>([]);
+	const reorderRoutesMutation = useReorderRoutes(wallId);
+
+	const sensors = useSensors(
+		useSensor(PointerSensor),
+		useSensor(TouchSensor, {
+			activationConstraint: { delay: 250, tolerance: 5 },
+		}),
+	);
+
+	function handleStartReorder() {
+		setReorderList([...routes]);
+		setIsReordering(true);
+	}
+
+	function handleDragEnd(event: DragEndEvent) {
+		const { active, over } = event;
+		if (over && active.id !== over.id) {
+			setReorderList((prev) => {
+				const oldIndex = prev.findIndex((r) => r.id === active.id);
+				const newIndex = prev.findIndex((r) => r.id === over.id);
+				return arrayMove(prev, oldIndex, newIndex);
+			});
+		}
+	}
+
+	async function handleSaveOrder() {
+		await reorderRoutesMutation.mutateAsync(reorderList.map((r) => r.id));
+		setIsReordering(false);
+	}
+
 	const dataModalRoute = dataModalRouteId
 		? routes.find((r) => r.id === dataModalRouteId)
 		: null;
@@ -237,7 +331,12 @@ const WallView = () => {
 					lines={wallTopoLines}
 					routes={routes
 						.filter((r) => r.status === "verified")
-						.map((r) => ({ id: r.id, name: r.name, grade: r.grade, route_type: r.route_type }))}
+						.map((r) => ({
+							id: r.id,
+							name: r.name,
+							grade: r.grade,
+							route_type: r.route_type,
+						}))}
 					onClose={() => setShowTopoModal(false)}
 				/>
 			)}
@@ -285,42 +384,82 @@ const WallView = () => {
 				</p>
 			)}
 
-			{routes.map((route) => (
-				<div
-					key={route.id}
-					className="rounded-lg bg-surface-card p-4 flex items-center gap-2"
+			{isAdmin &&
+				routes.length > 1 &&
+				(isReordering ? (
+					<button
+						type="button"
+						onClick={handleSaveOrder}
+						disabled={reorderRoutesMutation.isPending}
+						className="text-sm text-accent-primary font-semibold text-left"
+					>
+						{reorderRoutesMutation.isPending ? "Saving…" : "Done"}
+					</button>
+				) : (
+					<button
+						type="button"
+						onClick={handleStartReorder}
+						className="text-sm text-accent-primary text-left"
+					>
+						Edit order
+					</button>
+				))}
+
+			{isReordering ? (
+				<DndContext
+					sensors={sensors}
+					collisionDetection={closestCenter}
+					onDragEnd={handleDragEnd}
 				>
-					<button
-						type="button"
-						disabled={route.status === "pending"}
-						className="flex-1 text-left flex items-center justify-between gap-2 disabled:opacity-60"
-						onClick={() =>
-							navigate({
-								to: "/routes/$routeId",
-								params: { routeId: route.id },
-							})
-						}
+					<SortableContext
+						items={reorderList.map((r) => r.id)}
+						strategy={verticalListSortingStrategy}
 					>
-						<span className="font-medium">{route.name}</span>
-						<div className="flex items-center gap-2">
-							<span className="text-xs text-text-secondary">{route.grade}</span>
-							<span className="text-xs text-text-tertiary">
-								{route.route_type}
-							</span>
-							{route.status === "pending" && (
-								<span className="text-xs text-amber-400">pending</span>
-							)}
-						</div>
-					</button>
-					<button
-						type="button"
-						className="shrink-0 text-xs text-accent-primary font-semibold"
-						onClick={() => setDataModalRouteId(route.id)}
+						{reorderList.map((route) => (
+							<SortableRouteCard key={route.id} route={route} />
+						))}
+					</SortableContext>
+				</DndContext>
+			) : (
+				routes.map((route) => (
+					<div
+						key={route.id}
+						className="rounded-lg bg-surface-card p-4 flex items-center gap-2"
 					>
-						Data
-					</button>
-				</div>
-			))}
+						<button
+							type="button"
+							disabled={route.status === "pending"}
+							className="flex-1 text-left flex items-center justify-between gap-2 disabled:opacity-60"
+							onClick={() =>
+								navigate({
+									to: "/routes/$routeId",
+									params: { routeId: route.id },
+								})
+							}
+						>
+							<span className="font-medium">{route.name}</span>
+							<div className="flex items-center gap-2">
+								<span className="text-xs text-text-secondary">
+									{route.grade}
+								</span>
+								<span className="text-xs text-text-tertiary">
+									{route.route_type}
+								</span>
+								{route.status === "pending" && (
+									<span className="text-xs text-accent-secondary">pending</span>
+								)}
+							</div>
+						</button>
+						<button
+							type="button"
+							className="shrink-0 text-xs text-accent-primary font-semibold"
+							onClick={() => setDataModalRouteId(route.id)}
+						>
+							Data
+						</button>
+					</div>
+				))
+			)}
 
 			<Button
 				type="button"

--- a/supabase/migrations/20260322000000_routes_sort_order.sql
+++ b/supabase/migrations/20260322000000_routes_sort_order.sql
@@ -1,0 +1,13 @@
+-- Add sort_order to routes table for admin-defined wall layout ordering
+ALTER TABLE routes ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0;
+
+-- Backfill: set sort_order based on current alphabetical order per wall
+WITH ranked AS (
+  SELECT id, ROW_NUMBER() OVER (PARTITION BY wall_id ORDER BY name ASC) - 1 AS rn
+  FROM routes
+  WHERE deleted_at IS NULL
+)
+UPDATE routes
+SET sort_order = ranked.rn
+FROM ranked
+WHERE routes.id = ranked.id;


### PR DESCRIPTION
- Add sort_order column to routes_cache (SQLite v23) and Supabase migration
- fetchRoutes now orders by sort_order ASC, name ASC
- reorderRoutes() updates Supabase + local cache in one pass
- useReorderRoutes(wallId) mutation hook invalidates routes cache
- WallView: admins see "Edit order" link when >1 route; tapping enters DnD reorder mode (dnd-kit, same sensors/strategy as ClimbForm moves); "Done" saves and exits