### PR TITLE
fix: widen route_type to include trad across all files, closes #160

### DIFF
--- a/src/components/molecules/RouteBodyChart.tsx
+++ b/src/components/molecules/RouteBodyChart.tsx
@@ -28,7 +28,7 @@ type XMetric = "height" | "ape_index";
 
 interface Props {
 	routeId: string;
-	routeType: "sport" | "boulder";
+	routeType: "sport" | "boulder" | "trad";
 }
 
 export const RouteBodyChart = ({ routeId, routeType }: Props) => {

--- a/src/components/molecules/RouteDataModal.tsx
+++ b/src/components/molecules/RouteDataModal.tsx
@@ -6,7 +6,7 @@ interface RouteDataModalProps {
 	onClose: () => void;
 	routeId: string;
 	routeName: string;
-	routeType: "sport" | "boulder";
+	routeType: "sport" | "boulder" | "trad";
 }
 
 export function RouteDataModal({

--- a/src/features/climbs/climbs.schema.ts
+++ b/src/features/climbs/climbs.schema.ts
@@ -66,7 +66,7 @@ export const SentStatus = z.enum([
 ]);
 export type SentStatus = z.infer<typeof SentStatus>;
 
-export const RouteType = z.enum(["sport", "boulder"]);
+export const RouteType = z.enum(["sport", "boulder", "trad"]);
 export type RouteType = z.infer<typeof RouteType>;
 
 export const ClimbSchema = z.object({

--- a/src/features/grades/grades.queries.ts
+++ b/src/features/grades/grades.queries.ts
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { fetchGrades } from "./grades.service";
 
-export function useGrades(discipline: "sport" | "boulder") {
+export function useGrades(discipline: "sport" | "boulder" | "trad") {
 	return useQuery({
 		queryKey: ["grades", discipline],
 		queryFn: () => fetchGrades(discipline),

--- a/src/features/grades/grades.service.ts
+++ b/src/features/grades/grades.service.ts
@@ -3,7 +3,7 @@ import { supabase } from "@/lib/supabase";
 import type { Grade } from "./grades.schema";
 
 export async function fetchGrades(
-	discipline: "sport" | "boulder",
+	discipline: "sport" | "boulder" | "trad",
 ): Promise<Grade[]> {
 	const db = await getDb();
 	return db.select<Grade[]>(

--- a/src/features/routes/routes.queries.ts
+++ b/src/features/routes/routes.queries.ts
@@ -104,7 +104,7 @@ export function useEditRoute() {
 				wall_id: string;
 				name: string;
 				grade: string;
-				route_type: "sport" | "boulder";
+				route_type: "sport" | "boulder" | "trad";
 				description?: string;
 			};
 		}) => editRoute(id, values),
@@ -187,7 +187,7 @@ export function useUpdateRouteFields() {
 			values: {
 				name: string;
 				grade: string;
-				route_type: "sport" | "boulder";
+				route_type: "sport" | "boulder" | "trad";
 				description?: string;
 			};
 		}) => updateRouteFields(id, values),

--- a/src/features/routes/routes.service.ts
+++ b/src/features/routes/routes.service.ts
@@ -85,7 +85,7 @@ export async function editRoute(
 		wall_id: string;
 		name: string;
 		grade: string;
-		route_type: "sport" | "boulder";
+		route_type: "sport" | "boulder" | "trad";
 		description?: string;
 	},
 ): Promise<void> {
@@ -147,7 +147,7 @@ export type UnverifiedRoute = {
 	wall_id: string;
 	name: string;
 	grade: string;
-	route_type: "sport" | "boulder";
+	route_type: "sport" | "boulder" | "trad";
 	description: string | null;
 	status: "pending" | "verified" | "rejected";
 	created_by: string;
@@ -256,7 +256,7 @@ export async function updateRouteFields(
 	values: {
 		name: string;
 		grade: string;
-		route_type: "sport" | "boulder";
+		route_type: "sport" | "boulder" | "trad";
 		description?: string;
 	},
 ): Promise<void> {

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -66,7 +66,7 @@ const addClimbRoute = createRoute({
 		routeId: z.string().optional(),
 		routeName: z.string().optional(),
 		grade: z.string().optional(),
-		routeType: z.enum(["sport", "boulder"]).optional(),
+		routeType: z.enum(["sport", "boulder", "trad"]).optional(),
 	}),
 	component: AddClimbView,
 });

--- a/src/views/AddEditRouteView.tsx
+++ b/src/views/AddEditRouteView.tsx
@@ -65,7 +65,7 @@ const AddEditRouteView = ({ routeId }: AddEditRouteViewProps) => {
 
 	// Form state
 	const [name, setName] = useState("");
-	const [routeType, setRouteType] = useState<"sport" | "boulder">("sport");
+	const [routeType, setRouteType] = useState<"sport" | "boulder" | "trad">("sport");
 	const [grade, setGrade] = useState("");
 	const [description, setDescription] = useState("");
 	const [selection, setSelection] = useState<LocationSelection>({
@@ -274,13 +274,14 @@ const AddEditRouteView = ({ routeId }: AddEditRouteViewProps) => {
 				<Select
 					value={routeType}
 					onChange={(e) => {
-						const val = e.target.value as "sport" | "boulder";
+						const val = e.target.value as "sport" | "boulder" | "trad";
 						setRouteType(val);
 						setGrade("");
 					}}
 				>
 					<option value="sport">Sport</option>
 					<option value="boulder">Boulder</option>
+					<option value="trad">Trad</option>
 				</Select>
 
 				<Select

--- a/src/views/RouteDetailView.tsx
+++ b/src/views/RouteDetailView.tsx
@@ -69,7 +69,7 @@ const RouteDetailView = () => {
 	const updateRouteFields = useUpdateRouteFields();
 	const [editingMeta, setEditingMeta] = useState(false);
 	const [editName, setEditName] = useState("");
-	const [editRouteType, setEditRouteType] = useState<"sport" | "boulder">(
+	const [editRouteType, setEditRouteType] = useState<"sport" | "boulder" | "trad">(
 		"sport",
 	);
 	const [editGrade, setEditGrade] = useState("");
@@ -161,13 +161,14 @@ const RouteDetailView = () => {
 					<Select
 						value={editRouteType}
 						onChange={(e) => {
-							const val = e.target.value as "sport" | "boulder";
+							const val = e.target.value as "sport" | "boulder" | "trad";
 							setEditRouteType(val);
 							setEditGrade("");
 						}}
 					>
 						<option value="sport">Sport</option>
 						<option value="boulder">Boulder</option>
+						<option value="trad">Trad</option>
 					</Select>
 					<Select
 						value={
@@ -327,7 +328,7 @@ const RouteDetailView = () => {
 						lines={wallTopoLines}
 						routes={
 							route
-								? [{ id: route.id, name: route.name, grade: route.grade }]
+								? [{ id: route.id, name: route.name, grade: route.grade, route_type: route.route_type }]
 								: []
 						}
 						routeId={routeId}

--- a/src/views/admin/VerificationView.tsx
+++ b/src/views/admin/VerificationView.tsx
@@ -72,13 +72,13 @@ const EditRouteForm = ({
 	onSave: (values: {
 		name: string;
 		grade: string;
-		route_type: "sport" | "boulder";
+		route_type: "sport" | "boulder" | "trad";
 		description?: string;
 	}) => void;
 	onCancel: () => void;
 }) => {
 	const [name, setName] = useState(route.name);
-	const [routeType, setRouteType] = useState<"sport" | "boulder">(
+	const [routeType, setRouteType] = useState<"sport" | "boulder" | "trad">(
 		route.route_type,
 	);
 	const [grade, setGrade] = useState(route.grade);
@@ -95,7 +95,7 @@ const EditRouteForm = ({
 			<Select
 				value={routeType}
 				onChange={(e) => {
-					const val = e.target.value as "sport" | "boulder";
+					const val = e.target.value as "sport" | "boulder" | "trad";
 					setRouteType(val);
 					setGrade("");
 				}}
@@ -246,7 +246,7 @@ const RouteRow = ({ route }: { route: UnverifiedRoute }) => {
 	const handleSaveEdit = (values: {
 		name: string;
 		grade: string;
-		route_type: "sport" | "boulder";
+		route_type: "sport" | "boulder" | "trad";
 		description?: string;
 	}) => {
 		updateFields(


### PR DESCRIPTION
Add "trad" to all "sport" | "boulder" unions in schema, service, query, and view layers so trad routes don't cause type errors. Also adds a Trad option to route type selects in AddEditRoute and RouteDetailView.