### PR TITLE
fix: resolve offline loading hang and add auto-sync on reconnect, clo…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { Spinner } from "@/components/atoms/Spinner";
 import {
 	checkPendingDeepLink,
 	fetchAndApplyProfile,
+	fetchLocalUser,
 	fetchOrCreateSupabaseUser,
 	initDeepLinkHandler,
 	restoreSession,
@@ -67,7 +68,26 @@ function Bootstrap() {
 			// Refresh user location in background (don't block startup)
 			refreshUserLocation(setUserLocation);
 
-			const session = await restoreSession();
+			// If device is definitely offline, skip all network calls and load cached local user.
+			if (!navigator.onLine) {
+				const localUser = await fetchLocalUser();
+				if (localUser) setUser(localUser);
+				return null;
+			}
+
+			// Online path: restore session with a 5-second timeout so an
+			// expired-token network refresh cannot hang indefinitely.
+			let session: Session | null = null;
+			try {
+				session = await restoreSession();
+			} catch (err) {
+				console.warn("[Bootstrap] session restore failed, loading from cache:", err);
+				// Timed out or failed (captive portal, no upstream). Fall back to local cache.
+				const localUser = await fetchLocalUser();
+				if (localUser) setUser(localUser);
+				return null;
+			}
+
 			if (session) {
 				setSession(session);
 				const role = await fetchOrCreateSupabaseUser(

--- a/src/features/auth/README.md
+++ b/src/features/auth/README.md
@@ -82,7 +82,8 @@ Role is **not** read from `public.users.role` — always fetched from `user_role
 | `sendPasswordReset(email)` | `resetPasswordForEmail` — sends reset link; redirects via Supabase Edge Function → `betaapp://auth/callback` |
 | `updatePassword(newPassword)` | `updateUser({ password })` — call from ResetPasswordView after `PASSWORD_RECOVERY` event |
 | `sendMagicLink(email)` | `signInWithOtp` — sends magic link email; redirects via Supabase Edge Function → `betaapp://auth/callback` |
-| `restoreSession()` | `supabase.auth.getSession()` — call on app launch |
+| `restoreSession(timeoutMs?)` | `supabase.auth.getSession()` with a 5s timeout (default). Rejects on timeout so Bootstrap can fall back to local cache. Call on app launch. |
+| `fetchLocalUser()` | Reads the last-cached user from local SQLite `users`. Used as the offline fallback in Bootstrap. Returns `null` if never logged in. |
 | `signOut()` | Clears Supabase session |
 | `updateUserProfile(userId, profile)` | Upserts to Supabase `profiles` (throws on error), then updates local SQLite; returns updated User |
 | `fetchAndApplyProfile(userId)` | Fetches from Supabase `profiles`, merges into local SQLite `users`; returns updated User |
@@ -111,12 +112,19 @@ interface AuthStore {
 ## Session lifecycle
 
 ```
-App launch:
-  restoreSession() → if session exists → setSession
+App launch (online):
+  navigator.onLine check → true
+  restoreSession() [5s timeout] → if session exists → setSession
   fetchOrCreateSupabaseUser(id) → get role
   upsertLocalUser(id, email, role)
   fetchAndApplyProfile(id) → merge Supabase profile into local SQLite → setUser
   useSync fires (userId now defined)
+
+App launch (offline or timeout):
+  navigator.onLine check → false (or restoreSession times out)
+  fetchLocalUser() → load cached user from local SQLite → setUser (no setSession)
+  App renders with cached data; no sync attempted
+  When connectivity returns → window 'online' event fires → useSync.runSync() auto-triggered
 
 Login (password):
   signIn(email, password) → setSession

--- a/src/features/auth/auth.service.ts
+++ b/src/features/auth/auth.service.ts
@@ -34,11 +34,25 @@ export async function signUp(
 
 // ── Session restore ──────────────────────────────────────────────────────────
 
-export async function restoreSession(): Promise<Session | null> {
-	const {
-		data: { session },
-	} = await supabase.auth.getSession();
-	return session;
+export async function restoreSession(timeoutMs = 5_000): Promise<Session | null> {
+	const sessionPromise = supabase.auth.getSession().then(({ data }) => data.session);
+	return Promise.race([
+		sessionPromise,
+		new Promise<never>((_, reject) =>
+			setTimeout(
+				() => reject(new Error("[restoreSession] timed out")),
+				timeoutMs,
+			),
+		),
+	]);
+}
+
+export async function fetchLocalUser(): Promise<User | null> {
+	const db = await getDb();
+	const rows = await db.select<User[]>(
+		"SELECT * FROM users WHERE deleted_at IS NULL LIMIT 1",
+	);
+	return rows[0] ?? null;
 }
 
 // ── Sign out ─────────────────────────────────────────────────────────────────

--- a/src/features/sync/README.md
+++ b/src/features/sync/README.md
@@ -69,7 +69,13 @@ interface SyncStore {
 - On INSERT/UPDATE: calls `applyRemoteClimb(payload.new)` + invalidates `['climbs']`
 - Soft deletes arrive as UPDATE with `deleted_at` set — handled correctly
 
-**Cleanup:** Realtime channel is removed when `userId` becomes undefined (logout).
+**Online event listener (offline → online recovery):**
+- Adds a `window` `online` event listener on mount
+- When the device comes back online, `runSync()` fires automatically
+- Handles the case where the app launched offline (Bootstrap loaded from local cache) and later regained connectivity
+- Listener is cleaned up when `userId` changes or becomes undefined
+
+**Cleanup:** Realtime channel and `online` listener are removed when `userId` becomes undefined (logout).
 
 ---
 
@@ -82,18 +88,21 @@ Last-write-wins via `updated_at`. During a pull, `INSERT OR REPLACE` applies the
 ## Auth + sync lifecycle
 
 ```
-App launch:
-  useSync receives userId = undefined → no sync, no Realtime
-
-User logs in → userId set in auth.store:
-  useSync fires
+App launch (online):
+  useSync receives userId (set by Bootstrap) → runSync fires immediately
   Reads last_synced_at from sync_meta
   → null: full push → full pull → reference data pull → write last_synced_at
   → set: delta push → delta pull → reference data pull → write last_synced_at
   Realtime subscription starts (live updates from this point)
 
+App launch (offline):
+  Bootstrap loads user from local SQLite (no session set)
+  useSync receives userId → runSync fires → navigator.onLine false → setOffline(), returns
+  Realtime subscription starts (will connect when online)
+  When device comes online → window 'online' event → runSync fires automatically
+
 User logs out → userId becomes undefined:
-  useSync cleanup: Realtime channel removed
+  useSync cleanup: Realtime channel + online listener removed
   Local data retained (local-first — not deleted on logout)
   last_synced_at persists in sync_meta for next login
 ```

--- a/src/hooks/useSync.ts
+++ b/src/hooks/useSync.ts
@@ -96,6 +96,13 @@ export function useSync(userId: string | undefined) {
 		setTriggerSync(runSync);
 	}, [runSync, setTriggerSync]);
 
+	// Auto-sync when connectivity is restored (e.g. app launched offline then came online).
+	useEffect(() => {
+		if (!userId) return;
+		window.addEventListener("online", runSync);
+		return () => window.removeEventListener("online", runSync);
+	}, [userId, runSync]);
+
 	useEffect(() => {
 		if (!userId) return;
 


### PR DESCRIPTION
…ses #169

- restoreSession() races against a 5s timeout so expired-token refresh cannot hang indefinitely on poor/no connectivity
- Bootstrap checks navigator.onLine first; falls back to local SQLite cache (fetchLocalUser) when offline or on timeout
- useSync adds window 'online' listener to auto-trigger sync when connectivity is restored after an offline launch