### PR TITLE
feat: improve Button reusability and use Button atom for Add burn trigger, closes #173

### DIFF
--- a/src/components/README.md
+++ b/src/components/README.md
@@ -22,7 +22,7 @@ templates   Layout shells with no real data — just children/slots.
 ### Atoms
 | Component | Purpose |
 |---|---|
-| `Button` | Primary action button, touch-target safe (`min-h-[48px]`) |
+| `Button` | Action button. Props: `variant` (`primary` \| `secondary` \| `outlined` \| `unstyled`, default `primary`), `size` (`small` \| `medium` \| `large`, default `medium`). Medium and large enforce `min-h-[48px]` for Android touch targets. Defaults `type="button"` to prevent accidental form submission. |
 | `Input` | Text input with label support |
 | `Select` | Dropdown select |
 | `Spinner` | Loading indicator |
@@ -232,6 +232,8 @@ Follow these rules when creating or modifying any component:
 - `secondary` variant → `bg-accent-secondary text-white`
 - `outlined` variant → `border-accent-primary text-accent-primary`
 - All variants use `rounded-[var(--radius-md)]` and `font-semibold`
+- Default size is `medium` (`min-h-[48px]`); use `size="small"` for compact inline buttons (e.g. burn form actions)
+- Always defaults to `type="button"` — override with `type="submit"` in forms
 
 **ToggleGroup:**
 - Active state: `bg-accent-primary text-white`

--- a/src/components/atoms/Button.tsx
+++ b/src/components/atoms/Button.tsx
@@ -21,20 +21,18 @@ const variantClasses: Record<ButtonVariant, string> = {
 
 const sizeClasses: Record<ButtonSize, string> = {
 	small: "px-3 py-1 text-sm",
-	medium: "px-4 py-2 text-base",
-	large: "px-6 py-3 text-lg",
+	medium: "px-4 py-2 text-base min-h-[48px]",
+	large: "px-6 py-3 text-lg min-h-[48px]",
 };
 
-const defaultPadding = "px-4 py-2";
-
 export const Button = (props: ButtonProps) => {
-	const { className, type, variant = "primary", size, ...rest } = props;
+	const { className, type = "button", variant = "primary", size = "medium", ...rest } = props;
 	return (
 		<button
 			className={cn(
 				"cursor-pointer rounded-[var(--radius-md)] font-semibold transition-colors",
 				variantClasses[variant],
-				size ? sizeClasses[size] : defaultPadding,
+				sizeClasses[size],
 				className,
 			)}
 			type={type}

--- a/src/views/ClimbDetailView.tsx
+++ b/src/views/ClimbDetailView.tsx
@@ -233,18 +233,19 @@ const ClimbDetailView = () => {
 				</button>
 				{burnsOpen && (
 					<div className="flex flex-col gap-2 px-3 pb-3">
-						<button
-							type="button"
-							className="flex items-center gap-1 text-sm text-accent-primary self-start"
+						<Button
+							size="small"
+							variant="outlined"
+							className="flex items-center gap-1 self-start"
 							onClick={() => {
 								setShowAddBurn(!showAddBurn);
 								setAddDate(new Date().toISOString().slice(0, 10));
 								setAddNotes("");
 							}}
 						>
-							<Plus size={16} />
+							<Plus size={14} />
 							Add burn
-						</button>
+						</Button>
 
 						{showAddBurn && (
 							<div className="rounded-[var(--radius-md)] bg-surface-input p-3 flex flex-col gap-2">


### PR DESCRIPTION
- Default type="button" to prevent accidental form submission
- Default size="medium" (consolidates defaultPadding constant)
- Add min-h-[48px] to medium and large sizes for Android touch targets
- Replace raw <button> "Add burn" toggle in ClimbDetailView with Button size="small" variant="outlined"
- Update components README with accurate Button docs and usage notes

https://claude.ai/code/session_01P8oEnt5yg9AEAjZPac5NqU