### PR TITLE
feat: add formatDate utility and standardise date display to DD-MM-YY, closes #174

### DIFF
--- a/src/lib/README.md
+++ b/src/lib/README.md
@@ -161,6 +161,26 @@ Wraps `clsx` + `tailwind-merge`. Use for all conditional Tailwind class composit
 
 ---
 
+## date.ts — date display formatting
+
+```ts
+import { formatDate } from '@/lib/date'
+```
+
+### `formatDate(date, format?): string`
+
+Formats a date for display. Accepts a `Date` object, an ISO timestamp string, or a `YYYY-MM-DD` date string. The optional `format` argument uses `DD`, `MM`, `YY`, and `YYYY` tokens; defaults to `'DD-MM-YY'`.
+
+```ts
+formatDate('2025-03-05')               // '05-03-25'
+formatDate('2025-03-05', 'DD/MM/YYYY') // '05/03/2025'
+formatDate(someIsoTimestamp)           // e.g. '05-03-25'
+```
+
+Use this function for **every** date shown to the user — never call `toLocaleDateString()` or render a raw date string directly.
+
+---
+
 ## units.ts — imperial/metric conversion
 
 ```ts

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,0 +1,36 @@
+/**
+ * Format a date value for display.
+ *
+ * @param date - A Date object, ISO timestamp string, or YYYY-MM-DD date string.
+ * @param format - Format string using tokens DD, MM, YY, YYYY. Defaults to 'DD-MM-YY'.
+ * @returns Formatted date string.
+ *
+ * @example
+ * formatDate('2025-03-05')              // '05-03-25'
+ * formatDate('2025-03-05', 'DD/MM/YYYY') // '05/03/2025'
+ * formatDate(new Date(), 'MM-DD-YY')    // e.g. '03-05-25'
+ */
+export function formatDate(date: string | Date, format = 'DD-MM-YY'): string {
+	let d: Date;
+
+	if (date instanceof Date) {
+		d = date;
+	} else if (/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+		// Date-only string — parse as local time to avoid UTC offset shifting the day
+		const [year, month, day] = date.split('-').map(Number);
+		d = new Date(year, month - 1, day);
+	} else {
+		d = new Date(date);
+	}
+
+	const dd = String(d.getDate()).padStart(2, '0');
+	const mm = String(d.getMonth() + 1).padStart(2, '0');
+	const yyyy = String(d.getFullYear());
+	const yy = yyyy.slice(-2);
+
+	return format
+		.replace('YYYY', yyyy)
+		.replace('DD', dd)
+		.replace('MM', mm)
+		.replace('YY', yy);
+}

--- a/src/views/ClimbDetailView.tsx
+++ b/src/views/ClimbDetailView.tsx
@@ -1,6 +1,7 @@
 import { useNavigate, useParams } from "@tanstack/react-router";
 import { ChevronDown, ExternalLink, Pencil, Plus, Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
+import { formatDate } from "@/lib/date";
 import { Button } from "@/components/atoms/Button";
 import { FeelSlider } from "@/components/atoms/FeelSlider";
 import { Input } from "@/components/atoms/Input";
@@ -343,7 +344,7 @@ const ClimbDetailView = () => {
 										) : (
 											<div className="flex items-center justify-between">
 												<div>
-													<p className="text-sm font-semibold">{burn.date}</p>
+													<p className="text-sm font-semibold">{formatDate(burn.date)}</p>
 													{burn.feel != null && (
 														<p className="text-xs text-accent-primary">
 															{FEEL_LABELS[burn.feel]}

--- a/src/views/admin/VerificationView.tsx
+++ b/src/views/admin/VerificationView.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { formatDate } from "@/lib/date";
 import { Button } from "@/components/atoms/Button";
 import { Input } from "@/components/atoms/Input";
 import { Select } from "@/components/atoms/Select";
@@ -292,7 +293,7 @@ const RouteRow = ({ route }: { route: UnverifiedRoute }) => {
 					</span>
 				</div>
 				<span className="text-xs text-text-tertiary">
-					{new Date(route.created_at).toLocaleDateString()}
+					{formatDate(route.created_at)}
 				</span>
 			</div>
 			{submitterLabel && (
@@ -445,7 +446,7 @@ const LocationRow = ({
 				</p>
 			</div>
 			<span className="text-xs text-text-tertiary shrink-0">
-				{new Date(item.created_at).toLocaleDateString()}
+				{formatDate(item.created_at)}
 			</span>
 		</div>
 


### PR DESCRIPTION
- Add src/lib/date.ts with formatDate(date, format?) defaulting to 'DD-MM-YY'
- Replace toLocaleDateString() calls in VerificationView with formatDate
- Replace raw burn.date render in ClimbDetailView with formatDate
- Document the utility in src/lib/README.md

https://claude.ai/code/session_01JLkikYfFfPHA9aULKTosr1