### PR TITLE
feat: move beta above burns and navigate to route detail after add, closes #176 #180

### DIFF
--- a/src/views/AddEditRouteView.tsx
+++ b/src/views/AddEditRouteView.tsx
@@ -159,7 +159,7 @@ const AddEditRouteView = ({ routeId }: AddEditRouteViewProps) => {
 				});
 				addToast({ message: "Route updated", type: "success" });
 			} else {
-				await addRoute({
+				const newRouteId = await addRoute({
 					values: parsed.data,
 					userId: user?.id ?? "",
 					isAdmin,
@@ -168,6 +168,12 @@ const AddEditRouteView = ({ routeId }: AddEditRouteViewProps) => {
 					message: isAdmin ? "Route added" : "Route submitted for review",
 					type: "success",
 				});
+				router.navigate({
+					to: "/routes/$routeId",
+					params: { routeId: newRouteId },
+					replace: true,
+				});
+				return;
 			}
 			router.history.back();
 		} catch {

--- a/src/views/ClimbDetailView.tsx
+++ b/src/views/ClimbDetailView.tsx
@@ -220,6 +220,50 @@ const ClimbDetailView = () => {
 				onCancel={() => setPendingDeleteBurnId(null)}
 			/>
 
+			{betas.length === 0 ? (
+				<div className="rounded-md bg-surface-card px-3 py-3">
+					<p className="text-sm text-text-secondary">No betas logged yet.</p>
+				</div>
+			) : (
+				betas.map((beta) => (
+					<div key={beta.id} className="rounded-md bg-surface-card">
+						<button
+							type="button"
+							className="flex items-center justify-between w-full p-3 text-sm text-text-secondary"
+							onClick={() => toggleBeta(beta.id)}
+						>
+							<span>
+								{beta.title} ({beta.moves.length})
+							</span>
+							<ChevronDown
+								size={16}
+								className={cn(
+									"transition-transform",
+									openBetaIds.has(beta.id) && "rotate-180",
+								)}
+							/>
+						</button>
+						{openBetaIds.has(beta.id) &&
+							(beta.moves.length > 0 ? (
+								<ul className="flex flex-col gap-1 px-3 pb-3">
+									{beta.moves.map((move, i) => (
+										<li
+											key={move.id}
+											className="border-l border-text-primary pl-2 text-sm"
+										>
+											{i + 1}. {move.text}
+										</li>
+									))}
+								</ul>
+							) : (
+								<p className="text-sm text-text-secondary px-3 pb-3">
+									No moves logged yet.
+								</p>
+							))}
+					</div>
+				))
+			)}
+
 			<div className="rounded-md bg-surface-card">
 				<button
 					type="button"
@@ -390,50 +434,6 @@ const ClimbDetailView = () => {
 					</div>
 				)}
 			</div>
-
-			{betas.length === 0 ? (
-				<div className="rounded-md bg-surface-card px-3 py-3">
-					<p className="text-sm text-text-secondary">No betas logged yet.</p>
-				</div>
-			) : (
-				betas.map((beta) => (
-					<div key={beta.id} className="rounded-md bg-surface-card">
-						<button
-							type="button"
-							className="flex items-center justify-between w-full p-3 text-sm text-text-secondary"
-							onClick={() => toggleBeta(beta.id)}
-						>
-							<span>
-								{beta.title} ({beta.moves.length})
-							</span>
-							<ChevronDown
-								size={16}
-								className={cn(
-									"transition-transform",
-									openBetaIds.has(beta.id) && "rotate-180",
-								)}
-							/>
-						</button>
-						{openBetaIds.has(beta.id) &&
-							(beta.moves.length > 0 ? (
-								<ul className="flex flex-col gap-1 px-3 pb-3">
-									{beta.moves.map((move, i) => (
-										<li
-											key={move.id}
-											className="border-l border-text-primary pl-2 text-sm"
-										>
-											{i + 1}. {move.text}
-										</li>
-									))}
-								</ul>
-							) : (
-								<p className="text-sm text-text-secondary px-3 pb-3">
-									No moves logged yet.
-								</p>
-							))}
-					</div>
-				))
-			)}
 
 			{climb.link && (
 				<a


### PR DESCRIPTION
- ClimbDetailView: render beta sections above the burns collapsible (#176)
- AddEditRouteView: after creating a new route, navigate to /routes/$routeId
  instead of going back in history (#180)

https://claude.ai/code/session_01THX54NVj3wkg7kTn7WENAf