### PR TITLE
feat: configurable default home screen status filters, closes #192

### DIFF
--- a/src/components/molecules/FilterPanel.tsx
+++ b/src/components/molecules/FilterPanel.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef } from "react";
 import type { Climb } from "@/features/climbs/climbs.schema";
 import type { SortKey } from "@/features/climbs/climbs.store";
 import { useClimbsStore } from "@/features/climbs/climbs.store";
+import { useUiStore } from "@/stores/ui.store";
 import { cn } from "@/lib/cn";
 
 interface FilterPanelProps {
@@ -51,6 +52,7 @@ export const FilterPanel = ({ climbs }: FilterPanelProps) => {
 	const toggleTypeFilter = useClimbsStore((s) => s.toggleTypeFilter);
 	const sortKey = useClimbsStore((s) => s.sortKey);
 	const setSortKey = useClimbsStore((s) => s.setSortKey);
+	const defaultStatusFilters = useUiStore((s) => s.defaultStatusFilters);
 
 	const wrapperRef = useRef<HTMLDivElement>(null);
 
@@ -80,9 +82,8 @@ export const FilterPanel = ({ climbs }: FilterPanelProps) => {
 	};
 
 	const isNonDefault =
-		statusFilters.size !== 2 ||
-		!statusFilters.has("sent") ||
-		!statusFilters.has("project") ||
+		statusFilters.size !== defaultStatusFilters.size ||
+		[...defaultStatusFilters].some((s) => !statusFilters.has(s)) ||
 		typeFilters.size !== 2 ||
 		sortKey !== "name_asc";
 

--- a/src/features/README.md
+++ b/src/features/README.md
@@ -48,6 +48,13 @@ addToast({ message: 'Saved', type: 'success' })
 
 **Toast types:** `'success' | 'error' | 'warning'`
 
+**Persisted keys (localStorage):**
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `betaapp-theme` | `"dark" \| "light"` | `"dark"` | App color theme |
+| `betaapp-user-location` | `{ lat, lng }` JSON | `null` | Last known map center |
+| `betaapp-default-status-filters` | `string[]` JSON | `["project"]` | Default home screen status filters (configurable in Profile → Settings) |
+
 ---
 
 ## Patterns

--- a/src/features/climbs/README.md
+++ b/src/features/climbs/README.md
@@ -159,7 +159,7 @@ interface ClimbsStore {
   setSearchText: (text: string) => void
   filtersOpen: boolean
   setFiltersOpen: (open: boolean) => void
-  statusFilters: Set<string>          // default: sent, project
+  statusFilters: Set<string>          // initialized from localStorage betaapp-default-status-filters (default: project)
   toggleStatusFilter: (status: string) => void
   typeFilters: Set<string>            // default: sport, boulder
   toggleTypeFilter: (type: string) => void

--- a/src/features/climbs/climbs.store.ts
+++ b/src/features/climbs/climbs.store.ts
@@ -1,5 +1,17 @@
 import { create } from "zustand";
 
+const storedDefaultStatusFilters: Set<string> = (() => {
+	try {
+		const raw = localStorage.getItem("betaapp-default-status-filters");
+		if (!raw) return new Set(["project"]);
+		const parsed = JSON.parse(raw);
+		if (Array.isArray(parsed)) return new Set(parsed);
+		return new Set(["project"]);
+	} catch {
+		return new Set(["project"]);
+	}
+})();
+
 export type SortKey =
 	| "name_asc"
 	| "name_desc"
@@ -33,7 +45,7 @@ export const useClimbsStore = create<ClimbsStore>((set) => ({
 	setSearchText: (searchText) => set({ searchText }),
 	filtersOpen: false,
 	setFiltersOpen: (filtersOpen) => set({ filtersOpen }),
-	statusFilters: new Set(["sent", "project"]),
+	statusFilters: storedDefaultStatusFilters,
 	toggleStatusFilter: (status) =>
 		set((state) => {
 			const next = new Set(state.statusFilters);

--- a/src/stores/ui.store.ts
+++ b/src/stores/ui.store.ts
@@ -21,10 +21,24 @@ interface UiStore {
 	/** When set, the Android back button calls this instead of navigating back. */
 	backHandlerOverride: (() => void) | null;
 	setBackHandlerOverride: (fn: (() => void) | null) => void;
+	defaultStatusFilters: Set<string>;
+	setDefaultStatusFilters: (filters: Set<string>) => void;
 }
 
 const storedTheme =
 	(localStorage.getItem("betaapp-theme") as Theme | null) ?? "dark";
+
+const storedDefaultStatusFilters: Set<string> = (() => {
+	try {
+		const raw = localStorage.getItem("betaapp-default-status-filters");
+		if (!raw) return new Set(["project"]);
+		const parsed = JSON.parse(raw);
+		if (Array.isArray(parsed)) return new Set(parsed);
+		return new Set(["project"]);
+	} catch {
+		return new Set(["project"]);
+	}
+})();
 
 const storedLocation: UserLocation | null = (() => {
 	try {
@@ -64,4 +78,12 @@ export const useUiStore = create<UiStore>((set) => ({
 	},
 	backHandlerOverride: null,
 	setBackHandlerOverride: (fn) => set({ backHandlerOverride: fn }),
+	defaultStatusFilters: storedDefaultStatusFilters,
+	setDefaultStatusFilters: (filters) => {
+		localStorage.setItem(
+			"betaapp-default-status-filters",
+			JSON.stringify([...filters]),
+		);
+		set({ defaultStatusFilters: filters });
+	},
 }));

--- a/src/views/ProfileView.tsx
+++ b/src/views/ProfileView.tsx
@@ -224,6 +224,15 @@ const AuthenticatedProfile = ({
 	const addToast = useUiStore((s) => s.addToast);
 	const theme = useUiStore((s) => s.theme);
 	const setTheme = useUiStore((s) => s.setTheme);
+	const defaultStatusFilters = useUiStore((s) => s.defaultStatusFilters);
+	const setDefaultStatusFilters = useUiStore((s) => s.setDefaultStatusFilters);
+
+	const toggleDefaultStatus = (status: string) => {
+		const next = new Set(defaultStatusFilters);
+		if (next.has(status)) next.delete(status);
+		else next.add(status);
+		setDefaultStatusFilters(next);
+	};
 	const unit = user.default_unit ?? "imperial";
 	const { data: sportGrades = [] } = useGrades("sport");
 	const { data: boulderGrades = [] } = useGrades("boulder");
@@ -382,6 +391,25 @@ const AuthenticatedProfile = ({
 						value={theme}
 						onChange={(v) => setTheme(v as Theme)}
 					/>
+				</div>
+				<div>
+					<p className="text-sm mb-1">Home screen</p>
+					<div className="flex flex-wrap gap-x-4 gap-y-1">
+						{(["sent", "project", "todo"] as const).map((status) => (
+							<label
+								key={status}
+								className="flex items-center gap-2 text-sm cursor-pointer capitalize"
+							>
+								<input
+									type="checkbox"
+									checked={defaultStatusFilters.has(status)}
+									onChange={() => toggleDefaultStatus(status)}
+									className="accent-accent-primary w-4 h-4"
+								/>
+								{status}
+							</label>
+						))}
+					</div>
 				</div>
 			</div>
 


### PR DESCRIPTION
Default changed from sent+project to project only. Profile → Settings gains three checkboxes (Sent/Project/Todo) that persist the preference to localStorage and initialize the home screen filter on next launch.