### PR TITLE
feat: reusable GradeSelect molecule with correct defaults, closes #190

### DIFF
--- a/src/components/README.md
+++ b/src/components/README.md
@@ -35,6 +35,7 @@ templates   Layout shells with no real data — just children/slots.
 | `ClimbCard` | Displays a single climb summary; handles tap + delete |
 | `EditableDescription` | Read-only description text; admins see pencil icon for inline edit + save |
 | `FilterPanel` | Collapsible status/type filter checkboxes with cross-filtered counts |
+| `GradeSelect` | Controlled grade dropdown. Fetches grades for `routeType` via `useGrades`. Defaults empty value to `5.12a` (sport/trad) or `v5` (boulder). Props: `routeType`, `value`, `onChange`, optional `id`/`name`. |
 | `FormField` | Label + input/select + error message wrapper |
 | `SyncStatus` | Reads `sync.store` and renders sync state indicator |
 | `CoordinatePicker` | Fullscreen Leaflet overlay for picking coordinates; fixed center pin with drag-to-position pattern. Props: `value`, `defaultCenter`, `defaultZoom`, `markers` (reference pins), `onChange`, `onClose`. Exports `PickerMarker` type. |

--- a/src/components/molecules/GradeSelect.tsx
+++ b/src/components/molecules/GradeSelect.tsx
@@ -1,0 +1,42 @@
+import { Select } from "@/components/atoms/Select";
+import { useGrades } from "@/features/grades/grades.queries";
+
+const DEFAULT_GRADE: Record<"sport" | "boulder" | "trad", string> = {
+	sport: "5.12a",
+	trad: "5.12a",
+	boulder: "v5",
+};
+
+interface GradeSelectProps {
+	routeType: "sport" | "boulder" | "trad";
+	value: string;
+	onChange: (value: string) => void;
+	id?: string;
+	name?: string;
+}
+
+export const GradeSelect = ({
+	routeType,
+	value,
+	onChange,
+	id,
+	name,
+}: GradeSelectProps) => {
+	const { data: grades = [] } = useGrades(routeType);
+	const resolved = value || DEFAULT_GRADE[routeType];
+
+	return (
+		<Select
+			id={id}
+			name={name}
+			value={resolved}
+			onChange={(e) => onChange(e.target.value)}
+		>
+			{grades.map((g) => (
+				<option key={g.id} value={g.grade}>
+					{g.grade}
+				</option>
+			))}
+		</Select>
+	);
+};

--- a/src/components/organisms/ClimbForm.tsx
+++ b/src/components/organisms/ClimbForm.tsx
@@ -34,7 +34,7 @@ import {
 	type RouteType,
 	type SentStatus,
 } from "@/features/climbs/climbs.schema";
-import { useGrades } from "@/features/grades/grades.queries";
+import { GradeSelect } from "@/components/molecules/GradeSelect";
 import type { Route } from "@/features/routes/routes.schema";
 import { cn } from "@/lib/cn";
 
@@ -373,8 +373,6 @@ export const ClimbForm = ({
 
 	// ── Form ──────────────────────────────────────────────────────────────────
 
-	const { data: grades = [] } = useGrades(routeType);
-
 	const form = useForm({
 		canSubmitWhenInvalid: true,
 		defaultValues: {
@@ -452,7 +450,10 @@ export const ClimbForm = ({
 										const newType = e.target.value as RouteType;
 										field.handleChange(newType);
 										setRouteType(newType);
-										form.setFieldValue("grade", "");
+										form.setFieldValue(
+							"grade",
+							newType === "boulder" ? "v5" : "5.12a",
+						);
 									}}
 									name="route_type"
 								>
@@ -469,21 +470,13 @@ export const ClimbForm = ({
 						</label>
 						<form.Field name="grade">
 							{(field) => (
-								<Select
+								<GradeSelect
 									id="grade"
-									value={
-										field.state.value ||
-										(routeType === "boulder" ? "v0" : "5.10a")
-									}
-									onChange={(e) => field.handleChange(e.target.value)}
 									name="grade"
-								>
-									{grades.map((g) => (
-										<option key={g.id} value={g.grade}>
-											{g.grade}
-										</option>
-									))}
-								</Select>
+									routeType={routeType}
+									value={field.state.value}
+									onChange={(v) => field.handleChange(v)}
+								/>
 							)}
 						</form.Field>
 					</div>

--- a/src/views/AddEditRouteView.tsx
+++ b/src/views/AddEditRouteView.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/components/molecules/LocationDrillDown";
 import { Sheet } from "@/components/molecules/Sheet";
 import { useAuthStore } from "@/features/auth/auth.store";
-import { useGrades } from "@/features/grades/grades.queries";
+import { GradeSelect } from "@/components/molecules/GradeSelect";
 import {
 	useCrag,
 	useRegion,
@@ -113,7 +113,6 @@ const AddEditRouteView = ({ routeId }: AddEditRouteViewProps) => {
 		setPendingSelection(sel);
 	}, []);
 
-	const { data: grades = [] } = useGrades(routeType);
 	const { mutateAsync: addRoute, isPending: adding } = useAddRoute();
 	const { mutateAsync: editRoute, isPending: editing } = useEditRoute();
 
@@ -130,7 +129,7 @@ const AddEditRouteView = ({ routeId }: AddEditRouteViewProps) => {
 	const canSubmit = !!selection.wallId && name.trim().length > 0;
 
 	const handleSubmit = async () => {
-		const resolvedGrade = grade || (grades.length > 0 ? grades[0].grade : "");
+		const resolvedGrade = grade || (routeType === "boulder" ? "v5" : "5.12a");
 		const parsed = RouteSubmitSchema.safeParse({
 			wall_id: selection.wallId,
 			name: name.trim(),
@@ -284,7 +283,7 @@ const AddEditRouteView = ({ routeId }: AddEditRouteViewProps) => {
 					onChange={(e) => {
 						const val = e.target.value as "sport" | "boulder" | "trad";
 						setRouteType(val);
-						setGrade("");
+						setGrade(val === "boulder" ? "v5" : "5.12a");
 					}}
 				>
 					<option value="sport">Sport</option>
@@ -292,16 +291,11 @@ const AddEditRouteView = ({ routeId }: AddEditRouteViewProps) => {
 					<option value="trad">Trad</option>
 				</Select>
 
-				<Select
-					value={grade || (grades.length > 0 ? grades[0].grade : "")}
-					onChange={(e) => setGrade(e.target.value)}
-				>
-					{grades.map((g) => (
-						<option key={g.id} value={g.grade}>
-							{g.grade}
-						</option>
-					))}
-				</Select>
+				<GradeSelect
+					routeType={routeType}
+					value={grade}
+					onChange={setGrade}
+				/>
 
 				<textarea
 					placeholder="Description (optional)"

--- a/src/views/SubmitRouteView.tsx
+++ b/src/views/SubmitRouteView.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/atoms/Button";
 import { Input } from "@/components/atoms/Input";
 import { Select } from "@/components/atoms/Select";
 import { useAuthStore } from "@/features/auth/auth.store";
-import { useGrades } from "@/features/grades/grades.queries";
+import { GradeSelect } from "@/components/molecules/GradeSelect";
 import { useSubmitRoute } from "@/features/routes/routes.queries";
 import { RouteSubmitSchema } from "@/features/routes/routes.schema";
 import { useUiStore } from "@/stores/ui.store";
@@ -18,7 +18,6 @@ const SubmitRouteView = () => {
 	const { mutateAsync: submitRoute } = useSubmitRoute();
 
 	const [routeType, setRouteType] = useState<"sport" | "boulder">("sport");
-	const { data: grades = [] } = useGrades(routeType);
 
 	const form = useForm({
 		canSubmitWhenInvalid: true,
@@ -29,7 +28,7 @@ const SubmitRouteView = () => {
 			description: "",
 		},
 		onSubmit: async ({ value }) => {
-			const grade = value.grade || (grades.length > 0 ? grades[0].grade : "");
+			const grade = value.grade || (routeType === "boulder" ? "v5" : "5.12a");
 			const parsed = RouteSubmitSchema.safeParse({
 				wall_id: wallId,
 				name: value.name,
@@ -100,6 +99,7 @@ const SubmitRouteView = () => {
 								const val = e.target.value as "sport" | "boulder";
 								field.handleChange(val);
 								setRouteType(val);
+								form.setFieldValue("grade", val === "boulder" ? "v5" : "5.12a");
 							}}
 						>
 							<option value="sport">Sport</option>
@@ -110,18 +110,11 @@ const SubmitRouteView = () => {
 
 				<form.Field name="grade">
 					{(field) => (
-						<Select
-							value={
-								field.state.value || (grades.length > 0 ? grades[0].grade : "")
-							}
-							onChange={(e) => field.handleChange(e.target.value)}
-						>
-							{grades.map((g) => (
-								<option key={g.id} value={g.grade}>
-									{g.grade}
-								</option>
-							))}
-						</Select>
+						<GradeSelect
+							routeType={routeType}
+							value={field.state.value}
+							onChange={(v) => field.handleChange(v)}
+						/>
 					)}
 				</form.Field>
 

--- a/src/views/admin/VerificationView.tsx
+++ b/src/views/admin/VerificationView.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/atoms/Button";
 import { Input } from "@/components/atoms/Input";
 import { Select } from "@/components/atoms/Select";
 import { CoordinatePicker } from "@/components/molecules/CoordinatePicker";
-import { useGrades } from "@/features/grades/grades.queries";
+import { GradeSelect } from "@/components/molecules/GradeSelect";
 import {
 	useAdminUpdateCragCoords,
 	usePendingLocations,
@@ -84,8 +84,6 @@ const EditRouteForm = ({
 	);
 	const [grade, setGrade] = useState(route.grade);
 	const [description, setDescription] = useState(route.description ?? "");
-	const { data: grades = [] } = useGrades(routeType);
-
 	return (
 		<div className="flex flex-col gap-2 mt-3 pt-3 border-t border-border-default">
 			<Input
@@ -98,22 +96,17 @@ const EditRouteForm = ({
 				onChange={(e) => {
 					const val = e.target.value as "sport" | "boulder" | "trad";
 					setRouteType(val);
-					setGrade("");
+					setGrade(val === "boulder" ? "v5" : "5.12a");
 				}}
 			>
 				<option value="sport">Sport</option>
 				<option value="boulder">Boulder</option>
 			</Select>
-			<Select
-				value={grade || (grades.length > 0 ? grades[0].grade : "")}
-				onChange={(e) => setGrade(e.target.value)}
-			>
-				{grades.map((g) => (
-					<option key={g.id} value={g.grade}>
-						{g.grade}
-					</option>
-				))}
-			</Select>
+			<GradeSelect
+				routeType={routeType}
+				value={grade}
+				onChange={setGrade}
+			/>
 			<textarea
 				placeholder="Description (optional)"
 				value={description}
@@ -129,7 +122,7 @@ const EditRouteForm = ({
 					onClick={() =>
 						onSave({
 							name,
-							grade: grade || (grades.length > 0 ? grades[0].grade : ""),
+							grade: grade || (routeType === "boulder" ? "v5" : "5.12a"),
 							route_type: routeType,
 							description: description || undefined,
 						})


### PR DESCRIPTION
Extracts grade dropdown into GradeSelect molecule (useGrades + default 5.12a/v5 logic). Replaces inline grade Select in ClimbForm, AddEditRouteView, SubmitRouteView, and VerificationView.