### PR TITLE
feat: sun/shade DB migration, types, and service functions, closes #220

### DIFF
--- a/src/features/locations/README.md
+++ b/src/features/locations/README.md
@@ -26,7 +26,7 @@ CountrySchema    = { id, name, code, sort_order, created_at, region_count }
 RegionSchema     = { id, country_id, name, sort_order, created_at, sub_region_count }
 SubRegionSchema  = { id, region_id, name, description?, sort_order, status, created_by?, created_at, crag_count }
 CragSchema       = { id, sub_region_id, name, description?, approach?, sort_order, status, created_by?, created_at, lat?, lng?, sport_count, trad_count, boulder_count, wall_count }
-WallSchema       = { id, crag_id, name, description?, approach?, sort_order, status, created_by?, created_at, lat?, lng?, wall_type, sport_count, trad_count, boulder_count, route_count }
+WallSchema       = { id, crag_id, name, description?, approach?, sort_order, status, created_by?, created_at, lat?, lng?, wall_type, sport_count, trad_count, boulder_count, route_count, sun_data?: SunData | null }
 
 // *_count fields are computed at query time via correlated subqueries — not stored columns
 
@@ -47,7 +47,7 @@ CREATE TABLE IF NOT EXISTS regions_cache   (id, country_id, name, sort_order, cr
 -- Populated on-demand / region download
 CREATE TABLE IF NOT EXISTS sub_regions_cache (id, region_id, name, description, sort_order, status, created_by, created_at);
 CREATE TABLE IF NOT EXISTS crags_cache       (id, sub_region_id, name, description, approach, sort_order, status, created_by, created_at, lat, lng, sport_count, trad_count, boulder_count);
-CREATE TABLE IF NOT EXISTS walls_cache       (id, crag_id, name, description, approach, sort_order, status, created_by, created_at, lat, lng, wall_type, sport_count, trad_count, boulder_count);
+CREATE TABLE IF NOT EXISTS walls_cache       (id, crag_id, name, description, approach, sort_order, status, created_by, created_at, lat, lng, wall_type, sport_count, trad_count, boulder_count, sun_data);
 
 -- Download tracking
 CREATE TABLE IF NOT EXISTS downloaded_regions (region_id TEXT PRIMARY KEY, downloaded_at TEXT, server_updated_at TEXT);
@@ -134,6 +134,7 @@ Admin submissions are auto-verified and immediately visible to all users. Non-ad
 | `adminUpdateCragCoords(id, lat, lng)` | Sets crag lat/lng in Supabase + local cache |
 | `adminUpdateWallCoords(id, lat, lng, cragId)` | Sets wall lat/lng in local cache + Supabase (warns on Supabase failure); triggers `inheritWallCoordsToCrag` |
 | `adminUpdateWallType(id, wallType)` | Sets wall_type in Supabase + local cache |
+| `updateWallSunData(wallId, data)` | Sets sun_data (JSON-serialised `SunData`) in Supabase + local cache |
 | `inheritWallCoordsToCrag(cragId, lat, lng)` | One-time write-back: copies wall coords to crag if crag has no coords |
 
 Admin writes go directly to Supabase. The local cache refreshes on next `pullCountries()` / `pullRegions()`.
@@ -180,7 +181,7 @@ public.regions     (id, country_id, name, sort_order, created_at, updated_at)
 -- updated_at: maintained by trigger; bumped whenever a sub_region/crag/wall/route in this region is changed
 public.sub_regions (id, region_id, name, sort_order, created_at)
 public.crags       (id, sub_region_id, name, description, approach, sort_order, created_at, lat, lng, sport_count, trad_count, boulder_count)
-public.walls       (id, crag_id, name, description, approach, sort_order, created_at, lat, lng, wall_type, sport_count, trad_count, boulder_count)
+public.walls       (id, crag_id, name, description, approach, sort_order, created_at, lat, lng, wall_type, sport_count, trad_count, boulder_count, sun_data)
 -- RLS: authenticated users SELECT only; service role writes
 -- crags and walls have optional lat/lng REAL columns for map coordinates
 -- wall_type: 'wall' | 'boulder' — physical feature type

--- a/src/features/locations/locations.schema.ts
+++ b/src/features/locations/locations.schema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { SubmissionStatus } from "@/features/routes/routes.schema";
+import type { SunData } from "@/lib/sun";
 
 export const WallType = z.enum(["wall", "boulder"]);
 export type WallType = z.infer<typeof WallType>;
@@ -69,6 +70,7 @@ export const WallSchema = z.object({
 	trad_count: z.number().default(0),
 	boulder_count: z.number().default(0),
 	route_count: z.number().default(0),
+	sun_data: z.custom<SunData | null>().optional(),
 });
 
 export type Country = z.infer<typeof CountrySchema>;

--- a/src/features/locations/locations.service.ts
+++ b/src/features/locations/locations.service.ts
@@ -1,5 +1,6 @@
 import { getDb } from "@/lib/db";
 import { supabase } from "@/lib/supabase";
+import type { SunData } from "@/lib/sun";
 import type {
 	Country,
 	Crag,
@@ -1225,5 +1226,25 @@ export async function adminUpdateWallType(
 	await db.execute("UPDATE walls_cache SET wall_type = ? WHERE id = ?", [
 		wallType,
 		id,
+	]);
+}
+
+// ── Sun data ─────────────────────────────────────────────────────────────────
+
+export async function updateWallSunData(
+	wallId: string,
+	data: SunData,
+): Promise<void> {
+	const serialized = JSON.stringify(data);
+	// biome-ignore lint/suspicious/noExplicitAny: sun_data not yet in generated Supabase types
+	const { error } = await (supabase.from("walls") as any)
+		.update({ sun_data: serialized })
+		.eq("id", wallId);
+	if (error) throw error;
+
+	const db = await getDb();
+	await db.execute("UPDATE walls_cache SET sun_data = ? WHERE id = ?", [
+		serialized,
+		wallId,
 	]);
 }

--- a/src/features/routes/README.md
+++ b/src/features/routes/README.md
@@ -21,6 +21,7 @@ RouteSchema = {
   sort_order: number   // admin-defined display order; default 0
   avg_rating?: number | null  // v29; denormalised average of linked climbs' ratings (#212)
   rating_count: number        // v30; count of rated climbs; default 0 (#212)
+  sun_data?: SunData | null   // v31; JSON sun/aspect data overriding wall-level sun_data (#220)
 }
 
 // Admin-only type — not stored in SQLite
@@ -82,7 +83,8 @@ CREATE TABLE IF NOT EXISTS routes_cache (
     created_at  TEXT NOT NULL DEFAULT (datetime('now')),
     sort_order  INTEGER NOT NULL DEFAULT 0,   -- v23; admin-defined display order
     avg_rating  REAL,                          -- v29; denormalised avg of linked climb ratings (#212)
-    rating_count INTEGER NOT NULL DEFAULT 0    -- v30; count of rated climbs (#212)
+    rating_count INTEGER NOT NULL DEFAULT 0,   -- v30; count of rated climbs (#212)
+    sun_data    TEXT                           -- v31; JSON-encoded SunData (#220)
 );
 ```
 
@@ -104,6 +106,7 @@ Only populated when the user downloads a region (see [`locations/README.md`](../
 | `searchVerifiedRoutes(query)` | Full-text search against Supabase `routes` (verified only, limit 10) |
 | `searchLocalRoutes(query)` | LIKE search on local `routes_cache` by name or grade (verified only, limit 30) |
 | `updateRouteDescription(id, description)` | Updates description in Supabase + local cache |
+| `updateRouteSunData(routeId, data)` | Sets route-level sun_data (JSON-serialised `SunData`, or `null` to clear) in Supabase + local cache |
 
 ### Route body stats
 

--- a/src/features/routes/routes.schema.ts
+++ b/src/features/routes/routes.schema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { SunData } from "@/lib/sun";
 
 export const SubmissionStatus = z.enum(["pending", "verified", "rejected"]);
 export type SubmissionStatus = z.infer<typeof SubmissionStatus>;
@@ -16,6 +17,7 @@ export const RouteSchema = z.object({
 	sort_order: z.number().int().default(0),
 	avg_rating: z.number().nullable().optional(),
 	rating_count: z.number().int().default(0),
+	sun_data: z.custom<SunData | null>().optional(),
 });
 
 export const RouteSubmitSchema = z.object({

--- a/src/features/routes/routes.service.ts
+++ b/src/features/routes/routes.service.ts
@@ -1,5 +1,6 @@
 import { getDb } from "@/lib/db";
 import { supabase } from "@/lib/supabase";
+import type { SunData } from "@/lib/sun";
 import type {
 	Route,
 	RouteBodyStat,
@@ -442,4 +443,25 @@ export async function applyRemoteRouteLink(link: RouteLink): Promise<void> {
 			link.deleted_at ?? null,
 		],
 	);
+}
+
+// ── Sun data ─────────────────────────────────────────────────────────────────
+
+export async function updateRouteSunData(
+	routeId: string,
+	data: SunData | null,
+): Promise<void> {
+	const serialized = data !== null ? JSON.stringify(data) : null;
+	// biome-ignore lint/suspicious/noExplicitAny: sun_data not yet in generated Supabase types
+	const { error } = await (supabase as any)
+		.from("routes")
+		.update({ sun_data: serialized })
+		.eq("id", routeId);
+	if (error) throw error;
+
+	const db = await getDb();
+	await db.execute("UPDATE routes_cache SET sun_data = ? WHERE id = ?", [
+		serialized,
+		routeId,
+	]);
 }

--- a/src/lib/README.md
+++ b/src/lib/README.md
@@ -80,6 +80,7 @@ Versioned migration runner. Maintains a `schema_version` table (single row) and 
 | v28 | `climb_links` table — per-climb external links (#205) |
 | v29 | `rating` (INTEGER, nullable) on `climbs`; `avg_rating` (REAL, nullable) on `routes_cache` (#212) |
 | v30 | `rating_count` (INTEGER, default 0) on `routes_cache` (#212) |
+| v31 | `sun_data` (TEXT, nullable) on `walls_cache` and `routes_cache` (#220) |
 
 ### Rules
 - Always use `?` positional parameters — never string interpolation (SQL injection)
@@ -185,6 +186,32 @@ formatDate(someIsoTimestamp)           // e.g. '05-03-25'
 ```
 
 Use this function for **every** date shown to the user — never call `toLocaleDateString()` or render a raw date string directly.
+
+---
+
+## sun.ts — sun/shade types and helpers
+
+```ts
+import { summarizeSunData, getEffectiveSunData } from '@/lib/sun'
+import type { SunData, SunExposure, Aspect, Month } from '@/lib/sun'
+```
+
+Types for wall and route sun exposure data, stored as JSON in the `sun_data` TEXT column.
+
+| Type | Values |
+|---|---|
+| `SunExposure` | `"full-sun"` \| `"partial-shade"` \| `"full-shade"` |
+| `Aspect` | `"N"` \| `"NE"` \| `"E"` \| `"SE"` \| `"S"` \| `"SW"` \| `"W"` \| `"NW"` |
+| `Month` | `1`–`12` (January = 1) |
+| `SunData` | `{ aspect?: Aspect; monthly?: { month: Month; exposure: SunExposure }[]; notes?: string }` |
+
+### `summarizeSunData(data: SunData): string`
+
+Returns a human-readable summary string (e.g. `"Faces SE · Full sun"`). Joins aspect, dominant monthly exposure, and notes with ` · `.
+
+### `getEffectiveSunData(route, wall): SunData | null`
+
+Returns `route.sun_data` if present, else `wall.sun_data`, else `null`. Both arguments only need a `{ sun_data?: SunData | null }` shape — no full `Route`/`Wall` type required.
 
 ---
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -646,6 +646,12 @@ const migrations: Migration[] = [
 			`ALTER TABLE routes_cache ADD COLUMN rating_count INTEGER NOT NULL DEFAULT 0`,
 		);
 	},
+
+	// v31: sun_data on walls_cache and routes_cache (#220)
+	async (db) => {
+		await db.execute(`ALTER TABLE walls_cache ADD COLUMN sun_data TEXT`);
+		await db.execute(`ALTER TABLE routes_cache ADD COLUMN sun_data TEXT`);
+	},
 ];
 
 export async function runMigrations(db: DbAdapter): Promise<void> {

--- a/src/lib/sun.ts
+++ b/src/lib/sun.ts
@@ -1,0 +1,39 @@
+export type SunExposure = "full-sun" | "partial-shade" | "full-shade";
+export type Aspect = "N" | "NE" | "E" | "SE" | "S" | "SW" | "W" | "NW";
+export type Month = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+
+export type SunData = {
+	aspect?: Aspect;
+	monthly?: { month: Month; exposure: SunExposure }[];
+	notes?: string;
+};
+
+const EXPOSURE_LABELS: Record<SunExposure, string> = {
+	"full-sun": "Full sun",
+	"partial-shade": "Partial shade",
+	"full-shade": "Full shade",
+};
+
+export function summarizeSunData(data: SunData): string {
+	const parts: string[] = [];
+	if (data.aspect) parts.push(`Faces ${data.aspect}`);
+	if (data.monthly?.length) {
+		const counts: Partial<Record<SunExposure, number>> = {};
+		for (const { exposure } of data.monthly) {
+			counts[exposure] = (counts[exposure] ?? 0) + 1;
+		}
+		const dominant = (Object.entries(counts) as [SunExposure, number][]).sort(
+			(a, b) => b[1] - a[1],
+		)[0][0];
+		parts.push(EXPOSURE_LABELS[dominant]);
+	}
+	if (data.notes) parts.push(data.notes);
+	return parts.join(" · ");
+}
+
+export function getEffectiveSunData(
+	route: { sun_data?: SunData | null },
+	wall: { sun_data?: SunData | null },
+): SunData | null {
+	return route.sun_data ?? wall.sun_data ?? null;
+}


### PR DESCRIPTION
- Migration v31: sun_data TEXT on walls_cache and routes_cache
- New src/lib/sun.ts: SunExposure, SunData, Aspect, Month types + summarizeSunData and getEffectiveSunData helpers
- Wall and Route schemas updated with sun_data?: SunData | null
- locations.service: updateWallSunData(wallId, data)
- routes.service: updateRouteSunData(routeId, data | null)
- Docs updated: src/lib/README.md, locations/README.md, routes/README.md

https://claude.ai/code/session_01N4PJiYyxSfUkj9HK2BvgLu