### PR TITLE
feat: per-climb offline image caching, closes #231

### DIFF
--- a/src/features/climb-images/README.md
+++ b/src/features/climb-images/README.md
@@ -16,7 +16,7 @@ CREATE TABLE climb_images (
   user_id       TEXT NOT NULL,
   image_url     TEXT NOT NULL,      -- storage path, e.g. "{userId}/{climbId}/{imageId}.jpg"
   sort_order    INTEGER NOT NULL DEFAULT 0,
-  local_data    TEXT,               -- base64 data URI; set while upload is pending, cleared after
+  local_data    TEXT,               -- base64 data URI; present while upload is pending OR when climb is marked offline_available
   upload_status TEXT NOT NULL DEFAULT 'uploaded',  -- 'pending' | 'uploaded' | 'error'
   created_at    TEXT NOT NULL DEFAULT (datetime('now')),
   deleted_at    TEXT                -- soft delete
@@ -60,7 +60,7 @@ CREATE TABLE climb_image_pins (
 
 | Function | Description |
 |---|---|
-| `fetchClimbImages(climbId)` | Returns images ordered by `sort_order`; signed URL for uploaded, base64 data URI for pending |
+| `fetchClimbImages(climbId)` | Returns images ordered by `sort_order`; prefers `local_data` (base64) when present, otherwise generates a signed URL for uploaded images |
 | `getUserImageCount(userId)` | Count of non-deleted images across all climb logs (for 100-cap enforcement) |
 | `insertClimbImage(climbId, userId, storagePath, sortOrder, localData?, uploadStatus?)` | Inserts a new row; defaults to `upload_status='uploaded'` |
 | `markImageUploaded(id)` | Sets `upload_status='uploaded'` after a successful upload |
@@ -68,6 +68,9 @@ CREATE TABLE climb_image_pins (
 | `softDeleteClimbImage(id)` | Sets `deleted_at` |
 | `reorderClimbImages(ids[])` | Updates `sort_order` for each id in the given order |
 | `applyRemoteClimbImage(image)` | `INSERT OR REPLACE` — always sets `upload_status='uploaded'` — used by sync pull |
+| `cacheImagesForOfflineClimb(climbId)` | Downloads bytes for all uploaded images with no `local_data` and stores them as base64 |
+| `clearClimbImageCache(climbId)` | Clears `local_data` for all uploaded images (called when offline mode is turned off) |
+| `cacheNewOfflineImages(userId)` | Calls `cacheImagesForOfflineClimb` for every climb with `offline_available=1`; called after each sync |
 | `fetchClimbImagePins(climbImageId)` | Returns pins ordered by `sort_order` |
 | `insertClimbImagePin(climbImageId, pinType, xPct, yPct, sortOrder, pointerDir?)` | Inserts a new pin; defaults `pointer_dir` to `'bottom'` |
 | `updateClimbImagePin(id, patch)` | Partial update of `x_pct`, `y_pct`, `description`, and/or `pointer_dir` |
@@ -89,6 +92,7 @@ CREATE TABLE climb_image_pins (
 | `useAddPin(climbImageId)` | Mutation; inserts pin at given x_pct/y_pct with optional `pointerDir` (default `'bottom'`) |
 | `useUpdatePin(climbImageId)` | Mutation; partial patch (position, description, or pointer_dir) |
 | `useDeletePin(climbImageId)` | Mutation; hard deletes pin |
+| `useSetClimbOfflineAvailable(climbId)` | Mutation; `(enable: boolean)` — when enabling: sets flag + downloads image bytes; when disabling: clears cache + clears flag |
 
 ---
 
@@ -97,7 +101,8 @@ CREATE TABLE climb_image_pins (
 - **Bucket:** `climb-images` (private)
 - **Path pattern:** `{userId}/{climbId}/{imageId}.jpg`
 - **Upload flow:** compress → `blobToBase64` → insert row with `upload_status='pending'` → upload if online → `markImageUploaded`
-- **Offline fallback:** `local_data` base64 URI serves as thumbnail src until upload completes
+- **Offline fallback:** `local_data` base64 URI is used when present — either pending upload or cached for offline access
+- **Per-climb offline caching:** when `climbs.offline_available=1`, all image bytes are stored as base64 in `local_data`; `cacheNewOfflineImages` is called after each sync to auto-cache new images
 - **Retry:** `uploadPendingImages(userId)` runs at the start of each sync cycle (via `useSync`) to flush the queue
 - **Display:** `createSignedUrl(path, 3600)` — 1hr expiry; query staleTime is 50min to ensure refresh before expiry
 

--- a/src/features/climb-images/climb-images.queries.ts
+++ b/src/features/climb-images/climb-images.queries.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAuthStore } from "@/features/auth/auth.store";
+import { setClimbOfflineAvailable } from "@/features/climbs/climbs.service";
 import {
 	blobToBase64,
 	resizeAndCompress,
@@ -9,6 +10,8 @@ import { supabase } from "@/lib/supabase";
 import { useUiStore } from "@/stores/ui.store";
 import type { PinType, PointerDir } from "./climb-images.schema";
 import {
+	cacheImagesForOfflineClimb,
+	clearClimbImageCache,
 	deleteClimbImagePin,
 	fetchClimbImagePins,
 	fetchClimbImages,
@@ -228,6 +231,36 @@ export function useDeletePin(climbImageId: string) {
 			qc.invalidateQueries({
 				queryKey: [CLIMB_IMAGE_PINS_KEY, climbImageId],
 			});
+		},
+	});
+}
+
+// ── Offline availability ──────────────────────────────────────────────────────
+
+export function useSetClimbOfflineAvailable(climbId: string) {
+	const qc = useQueryClient();
+	const addToast = useUiStore((s) => s.addToast);
+
+	return useMutation({
+		mutationFn: async (enable: boolean) => {
+			if (enable) {
+				await setClimbOfflineAvailable(climbId, true);
+				await cacheImagesForOfflineClimb(climbId);
+			} else {
+				await clearClimbImageCache(climbId);
+				await setClimbOfflineAvailable(climbId, false);
+			}
+		},
+		onSuccess: (_data, enable) => {
+			qc.invalidateQueries({ queryKey: ["climbs", climbId] });
+			qc.invalidateQueries({ queryKey: [CLIMB_IMAGES_KEY, climbId] });
+			addToast({
+				message: enable ? "Saved for offline" : "Offline copy removed",
+				type: "success",
+			});
+		},
+		onError: () => {
+			addToast({ message: "Failed to update offline status", type: "error" });
 		},
 	});
 }

--- a/src/features/climb-images/climb-images.service.ts
+++ b/src/features/climb-images/climb-images.service.ts
@@ -1,5 +1,9 @@
 import { getDb } from "@/lib/db";
-import { base64ToBlob, uploadBlobToStorage } from "@/lib/image-utils";
+import {
+	base64ToBlob,
+	blobToBase64,
+	uploadBlobToStorage,
+} from "@/lib/image-utils";
 import { supabase } from "@/lib/supabase";
 import type {
 	ClimbImage,
@@ -35,10 +39,11 @@ export async function fetchClimbImages(
 	return Promise.all(
 		rows.map(async (row) => {
 			const upload_status = row.upload_status ?? "uploaded";
-			const signed_url =
-				upload_status === "uploaded"
+			const signed_url = row.local_data
+				? row.local_data
+				: upload_status === "uploaded"
 					? await signUrl(row.image_url)
-					: (row.local_data ?? "");
+					: "";
 			return { ...row, upload_status, signed_url };
 		}),
 	);
@@ -136,6 +141,52 @@ export async function reorderClimbImages(ids: string[]): Promise<void> {
 			i,
 			ids[i],
 		]);
+	}
+}
+
+export async function cacheImagesForOfflineClimb(
+	climbId: string,
+): Promise<void> {
+	const db = await getDb();
+	const rows = await db.select<ClimbImage[]>(
+		`SELECT * FROM climb_images
+     WHERE climb_id = ? AND upload_status = 'uploaded'
+       AND local_data IS NULL AND deleted_at IS NULL`,
+		[climbId],
+	);
+	for (const row of rows) {
+		try {
+			const url = await signUrl(row.image_url);
+			const res = await fetch(url);
+			const blob = await res.blob();
+			const data = await blobToBase64(blob);
+			await db.execute("UPDATE climb_images SET local_data = ? WHERE id = ?", [
+				data,
+				row.id,
+			]);
+		} catch {
+			// Non-fatal: skip this image, retry next time
+		}
+	}
+}
+
+export async function clearClimbImageCache(climbId: string): Promise<void> {
+	const db = await getDb();
+	await db.execute(
+		"UPDATE climb_images SET local_data = NULL WHERE climb_id = ? AND upload_status = 'uploaded'",
+		[climbId],
+	);
+}
+
+export async function cacheNewOfflineImages(userId: string): Promise<void> {
+	const db = await getDb();
+	const climbs = await db.select<{ id: string }[]>(
+		`SELECT id FROM climbs
+     WHERE user_id = ? AND offline_available = 1 AND deleted_at IS NULL`,
+		[userId],
+	);
+	for (const { id } of climbs) {
+		await cacheImagesForOfflineClimb(id);
 	}
 }
 

--- a/src/features/climbs/README.md
+++ b/src/features/climbs/README.md
@@ -36,6 +36,7 @@ ClimbSchema = {
   created_at: string
   updated_at: string
   deleted_at?: string | null
+  offline_available: number  // 0 | 1 — 1 when images are cached locally for offline access (#231)
 }
 
 ClimbFormSchema = ClimbSchema minus (id, route_id, created_at, updated_at, deleted_at)
@@ -87,7 +88,8 @@ CREATE TABLE IF NOT EXISTS climbs (
     link             TEXT,
     route_id         TEXT,
     sent_date        TEXT,
-    rating           INTEGER,   -- v29; 1–5 stars; null = unrated (#212)
+    rating           INTEGER,              -- v29; 1–5 stars; null = unrated (#212)
+    offline_available INTEGER NOT NULL DEFAULT 0,  -- v32; 1 when images cached locally (#231)
     deleted_at       TEXT,
     created_at       TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at       TEXT NOT NULL DEFAULT (datetime('now'))
@@ -115,6 +117,7 @@ CREATE TABLE IF NOT EXISTS climbs (
 | `patchClimbStatus(id, sentStatus)` | Updates only `sent_status` |
 | `patchClimbRating(id, rating)` | Updates only `rating` (pass `null` to clear); then calls `refreshRouteAvgRating` on the linked route if any |
 | `patchClimbLink(id, link)` | Updates only `link` (pass `null` to clear; legacy — UI now uses `climb_links` table) |
+| `setClimbOfflineAvailable(climbId, available)` | Sets `offline_available` to 1 (`true`) or 0 (`false`) |
 | `fetchClimbLinks(climbId)` | All active links for a climb (soft-deleted excluded), ordered by `created_at ASC` |
 | `addClimbLink(climbId, userId, url, title?)` | Inserts to Supabase then SQLite; generates UUID locally |
 | `deleteClimbLink(id)` | Soft-deletes on Supabase (`deleted_at = now()`), hard-deletes from SQLite |

--- a/src/features/climbs/climbs.schema.ts
+++ b/src/features/climbs/climbs.schema.ts
@@ -90,6 +90,7 @@ export const ClimbSchema = z.object({
 	created_at: z.string(),
 	updated_at: z.string(),
 	deleted_at: z.string().nullable().optional(),
+	offline_available: z.number().int().default(0),
 });
 
 export type Climb = z.infer<typeof ClimbSchema>;

--- a/src/features/climbs/climbs.service.ts
+++ b/src/features/climbs/climbs.service.ts
@@ -1,6 +1,6 @@
+import { refreshRouteAvgRating } from "@/features/routes/routes.service";
 import { getDb } from "@/lib/db";
 import { supabase } from "@/lib/supabase";
-import { refreshRouteAvgRating } from "@/features/routes/routes.service";
 import type { Climb, ClimbFormValues, ClimbLink } from "./climbs.schema";
 import type { SortKey } from "./climbs.store";
 
@@ -224,10 +224,11 @@ export async function linkClimbToRoute(
 
 export async function unlinkClimbFromRoute(climbId: string): Promise<void> {
 	const db = await getDb();
-	const rows = await db.select<{ route_id: string | null; rating: number | null }[]>(
-		"SELECT route_id, rating FROM climbs WHERE id = ? AND deleted_at IS NULL",
-		[climbId],
-	);
+	const rows = await db.select<
+		{ route_id: string | null; rating: number | null }[]
+	>("SELECT route_id, rating FROM climbs WHERE id = ? AND deleted_at IS NULL", [
+		climbId,
+	]);
 	await db.execute(
 		"UPDATE climbs SET route_id = NULL WHERE id = ? AND deleted_at IS NULL",
 		[climbId],
@@ -322,12 +323,24 @@ export async function patchClimbLink(
 	);
 }
 
+export async function setClimbOfflineAvailable(
+	climbId: string,
+	available: boolean,
+): Promise<void> {
+	const db = await getDb();
+	await db.execute("UPDATE climbs SET offline_available = ? WHERE id = ?", [
+		available ? 1 : 0,
+		climbId,
+	]);
+}
+
 export async function softDeleteClimb(id: string): Promise<void> {
 	const db = await getDb();
-	const rows = await db.select<{ route_id: string | null; rating: number | null }[]>(
-		"SELECT route_id, rating FROM climbs WHERE id = ? AND deleted_at IS NULL",
-		[id],
-	);
+	const rows = await db.select<
+		{ route_id: string | null; rating: number | null }[]
+	>("SELECT route_id, rating FROM climbs WHERE id = ? AND deleted_at IS NULL", [
+		id,
+	]);
 	await db.execute(
 		"UPDATE climbs SET deleted_at = datetime('now') WHERE id = ?",
 		[id],

--- a/src/hooks/useSync.ts
+++ b/src/hooks/useSync.ts
@@ -2,6 +2,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect } from "react";
 import type { Burn } from "@/features/burns/burns.schema";
 import { applyRemoteBurn } from "@/features/burns/burns.service";
+import { cacheNewOfflineImages } from "@/features/climb-images/climb-images.service";
 import type { Climb } from "@/features/climbs/climbs.schema";
 import { applyRemoteClimb } from "@/features/climbs/climbs.service";
 import { pullGrades } from "@/features/grades/grades.service";
@@ -59,6 +60,7 @@ export function useSync(userId: string | undefined) {
 			await uploadPendingImages(userId);
 			await pushClimbImages(userId, since);
 			await pullClimbImages(userId, since);
+			await cacheNewOfflineImages(userId);
 			await pushClimbImagePins(userId, since);
 			await pullClimbImagePins(userId, since);
 			await pullGrades();

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -652,6 +652,13 @@ const migrations: Migration[] = [
 		await db.execute(`ALTER TABLE walls_cache ADD COLUMN sun_data TEXT`);
 		await db.execute(`ALTER TABLE routes_cache ADD COLUMN sun_data TEXT`);
 	},
+
+	// v32: offline_available flag on climbs (#231)
+	async (db) => {
+		await db.execute(
+			`ALTER TABLE climbs ADD COLUMN offline_available INTEGER NOT NULL DEFAULT 0`,
+		);
+	},
 ];
 
 export async function runMigrations(db: DbAdapter): Promise<void> {

--- a/src/views/ClimbDetailView.tsx
+++ b/src/views/ClimbDetailView.tsx
@@ -43,6 +43,7 @@ import {
 	useDeleteBurn,
 	useUpdateBurn,
 } from "@/features/burns/burns.queries";
+import { useSetClimbOfflineAvailable } from "@/features/climb-images/climb-images.queries";
 import {
 	useAddClimbLink,
 	useClimb,
@@ -693,6 +694,7 @@ const ClimbDetailView = () => {
 	const deleteClimb = useDeleteClimb();
 	const unlinkClimb = useUnlinkClimbFromRoute();
 	const linkClimb = useLinkClimbToRoute();
+	const setOfflineAvailable = useSetClimbOfflineAvailable(climbId);
 	const patchGrade = usePatchClimbGrade();
 	const patchRating = usePatchClimbRating();
 	const patchStatus = usePatchClimbStatus();
@@ -800,6 +802,11 @@ const ClimbDetailView = () => {
 						</h1>
 					)}
 					{location && <p className="text-sm text-white">{location}</p>}
+					{!!climb.offline_available && (
+						<span className="inline-flex items-center gap-1 text-xs text-accent-primary font-medium mt-0.5">
+							✓ Downloaded
+						</span>
+					)}
 				</div>
 
 				{/* Grade + gear icon */}
@@ -889,6 +896,20 @@ const ClimbDetailView = () => {
 										Link to route
 									</button>
 								)}
+								<button
+									type="button"
+									className="w-full text-left px-4 py-2.5 text-sm hover:bg-surface-hover flex items-center gap-2"
+									disabled={setOfflineAvailable.isPending}
+									onClick={() => {
+										setOfflineAvailable.mutate(!climb.offline_available);
+										setGearMenuOpen(false);
+									}}
+								>
+									{setOfflineAvailable.isPending && <Spinner size="sm" />}
+									{climb.offline_available
+										? "Remove offline copy"
+										: "Save for offline"}
+								</button>
 								<button
 									type="button"
 									className="w-full text-left px-4 py-2.5 text-sm text-destructive hover:bg-surface-hover"


### PR DESCRIPTION
Adds an "Available offline" toggle to the climb detail gear menu. When
enabled, all uploaded images for that climb are downloaded and stored as
base64 in `climb_images.local_data`, making them viewable without a
network connection. `fetchClimbImages` now prefers `local_data` over
generating a signed URL, so both pending-upload images and explicitly
cached images render offline. During each sync, `cacheNewOfflineImages`
auto-fetches new images for any climb marked offline. Toggling off clears
the cached bytes. A "✓ Downloaded" badge appears on the detail view when
a climb is offline-available.

Migration v32 adds `offline_available INTEGER NOT NULL DEFAULT 0` to
the `climbs` table.

https://claude.ai/code/session_018eps9UWsiWaNgrbGhrgKuR